### PR TITLE
RFC: test out new syntax for launch with type deduction

### DIFF
--- a/examples/cute/tutorial/sgemm_1_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_1_sycl.cpp
@@ -42,7 +42,7 @@
 namespace syclcompat {
   template <class F, int Dim>
   sycl::event launch(const sycl::nd_range<Dim> &range, sycl::queue q, const F& f) {
-    return q.parallel_for(detail::transform_nd_range<Dim>(range),  [=](sycl::nd_item<3>) { f(); });
+    return q.parallel_for(detail::transform_nd_range<Dim>(range),  [=](sycl::nd_item<Dim>) { f(); });
   }
   template <class F, int Dim>
   sycl::event launch(const sycl::nd_range<Dim> &range, const F& f) {


### PR DESCRIPTION
Prototype to test out a solution for https://github.com/intel/llvm/issues/17832 . Looking for review on the syntax. Is it OK to have to wrap the function in a lambda to gain the type deduction? Should the lambda be past as first or last argument?