### PR TITLE
Roll back some changes in #395 that resulted in a regression for FP8 GEMM

### DIFF
--- a/include/cutlass/fp8_to_fp16.h
+++ b/include/cutlass/fp8_to_fp16.h
@@ -159,7 +159,7 @@ template<int N>
 static inline void E5M2_to_FP16(cutlass::Array<uint8_t, N> const &xin, cutlass::Array<uint16_t, N> &xout) {
   // Adapted from https://github.com/pytorch/pytorch/blob/dfcfad2112933cc34247421ac0a4d3f19a1806c1/c10/util/Float8_e5m2.h#L30-L43
   CUTLASS_PRAGMA_UNROLL
-  for (int i = N - 1; i >= 0; i--) {
+  for (int i = 0; i < N; i++) {
     xout[i] = (static_cast<uint16_t>(xin[i])) << 8;
   }
 }


### PR DESCRIPTION
Fixes #410. The description of some changes introduced in #395 that are being rolled back are present at https://github.com/codeplaysoftware/cutlass-sycl/pull/395#discussion_r2134668532 and https://github.com/codeplaysoftware/cutlass-sycl/pull/395#discussion_r2134689059.

I didn't investigate why the optimization for using fewer registers for FP8 -> FP16 conversion by @jiyang1011 in https://github.com/codeplaysoftware/cutlass-sycl/pull/395#discussion_r2134679006 resulted in a regression, so once the root-cause is found & the problem is resolved, that optimization could potentially be reintroduced in a subsequent PR. 

cc @cfgfung