### PR TITLE
Refactor CausalMask logic in Flash Attention kernel for better code reuse and potential compiler optimization

### DIFF
--- a/applications/flash_attention_v2/kernel/xe_flash_attn_prefill.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_prefill.hpp
@@ -317,7 +317,7 @@ public:
       // different for each subgroup due to triangular nature of causal based operation
       static constexpr int barrier_scope = CausalMask ? 3 : 2;
       // MAIN LOOP: loop over K and V, perform fused attention + online softmax
-      for (int nblock = 0; nblock < nblock_limit - static_cast<int>(CausalMask); nblock++) {
+      for (int nblock = 0; nblock < nblock_limit - 1; nblock++) {
         barrier_arrive(barrier_scope);
         // 1) Load K (performed inside mmaQK)
         // 2) Create Tensor S
@@ -346,19 +346,19 @@ public:
         barrier_wait(barrier_scope);
       }
 
+      // 1) Load K (performed inside mmaQK)
+      // 2) Create Tensor S
+      Tensor tSr = make_tensor<ElementAccumulator>(Shape<Int<Vec>, Int<FragsM>, Int<FragsN>>{});
+      clear(tSr);
+      // 3) Perform GEMM S = Q*K
+      collective_mma.mmaQK(tSr, gQ,  gK(_, _, nblock_limit - 1, _), tSr, ceil_div(head_size_qk, QK_BLK_K), mainloop_params);
+      // we only need one block ahead, there is enough gap to prefetch it while doing softmax. because the gap between the two MMA is big,
+      // prefetching it the same way as cutlass K matrix does not make sense
+      for(int i=0; i< size<1>(pVgV); i++) {
+        prefetch(tiled_prefetch_v, pVgV(_, i, _ , nblock_limit - 1));
+      }
       if constexpr (CausalMask) {
         // BAND Matrix
-        // 1) Load K (performed inside mmaQK)
-        // 2) Create Tensor S
-        Tensor tSr = make_tensor<ElementAccumulator>(Shape<Int<Vec>, Int<FragsM>, Int<FragsN>>{});
-        clear(tSr);
-        // 3) Perform GEMM S = Q*K
-        collective_mma.mmaQK(tSr, gQ,  gK(_, _, nblock_limit - 1, _), tSr, ceil_div(head_size_qk, QK_BLK_K), mainloop_params);
-        // we only need one block ahead, there is enough gap to prefetch it while doing softmax. because the gap between the two MMA is big,
-        // prefetching it the same way as cutlass K matrix does not make sense
-        for(int i=0; i< size<1>(pVgV); i++) {
-          prefetch(tiled_prefetch_v, pVgV(_, i, _ , nblock_limit - 1));
-        }
         // mask the elements of each tile where j > i
         const int item_id = thread_idx % SubgroupSize;
         int col_idx = item_id + (nblock_limit - 1) * QK_BLK_N;
@@ -375,12 +375,11 @@ public:
             }
           }
         }
-
-        CollectiveSoftmaxEpilogue softmax(params.softmax);
-        softmax((nblock_limit - 1) == 0, tSr, max_reg, sum_reg, out_reg);
-
-        collective_mma.template mmaPV<VSlicer>(out_reg, tSr,  gV(_, _ , nblock_limit - 1), out_reg, mainloop_params);
       }
+      CollectiveSoftmaxEpilogue softmax(params.softmax);
+      softmax((nblock_limit - 1) == 0, tSr, max_reg, sum_reg, out_reg);
+
+      collective_mma.template mmaPV<VSlicer>(out_reg, tSr,  gV(_, _ , nblock_limit - 1), out_reg, mainloop_params);
 
       auto epilogue_params = CollectiveEpilogue::template get_updated_copies<is_var_len>(params.epilogue, params.problem_shape, sequence_length_shape, batch_coord);
       CollectiveEpilogue epilogue{epilogue_params, shared_storage.epilogue};


### PR DESCRIPTION
1.  Unified Loop Condition: Changed the loop from for (int nblock = 0; nblock < nblock_limit - CausalMask; nblock++) to for (int nblock = 0; nblock < nblock_limit - 1; nblock++). This standardizes the iteration for most blocks, treating the last block more consistently without relying on the CausalMask template parameter directly in the main loop bound. This could enhance performance in scenarios with large nblock_limit, as compilers are more aggressive with optimizations on consistent loop bodies.
2.  Shared Logic On The Last Block: Reuse the mmaQK, softmax, and mmaPV operations across both the CausalMask and None CausalMask. This eliminates code duplication, improves maintainability.