### PR TITLE
Enable -Werror and -Wall

### DIFF
--- a/.github/workflows/intel_test.yml
+++ b/.github/workflows/intel_test.yml
@@ -103,6 +103,7 @@ jobs:
           cmake -G Ninja  \
             -DCUTLASS_ENABLE_SYCL=ON \
             -DDPCPP_SYCL_TARGET=${{ matrix.sycl_target }} \
+            -DCMAKE_CXX_FLAGS="-Werror" \
             -DCUTLASS_SYCL_RUNNING_CI=ON
           cmake --build . 
       - name: Unit test

--- a/.github/workflows/intel_test_gpp_host.yml
+++ b/.github/workflows/intel_test_gpp_host.yml
@@ -84,6 +84,7 @@ jobs:
             -DCUTLASS_ENABLE_SYCL=ON \
             -DDPCPP_SYCL_TARGET=${{ matrix.sycl_target }} \
             -DCUTLASS_SYCL_RUNNING_CI=ON \
+            -DCMAKE_CXX_FLAGS="-Werror" \
             -DDPCPP_HOST_COMPILER=g++-13
           cmake --build .
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,18 @@
 
 if(CUTLASS_ENABLE_SYCL)
   cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+
+  # Silence warnings from GoogleTest headers
+  include_directories(SYSTEM
+      ${CMAKE_CURRENT_SOURCE_DIR}/_deps/googletest-src/googletest/include
+      ${CMAKE_CURRENT_SOURCE_DIR}/_deps/googletest-src/googlemock/include
+  )
+
+  # Silence warnings from GoogleBenchmark headers
+  include_directories(SYSTEM
+      ${CMAKE_CURRENT_SOURCE_DIR}/_deps/googlebenchmark-src/include
+  )
+
 else()
   cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
   cmake_policy(SET CMP0112 NEW)
@@ -121,6 +133,16 @@ if (CUTLASS_ENABLE_SYCL)
          DPCPP_SYCL_TARGET STREQUAL "intel_gpu_bmg_g21")
     set(SYCL_INTEL_TARGET ON)
     add_compile_definitions(SYCL_INTEL_TARGET)
+    add_compile_options(-Wall
+       -Wno-unused-variable
+       -Wno-unused-local-typedef
+       -Wno-unused-but-set-variable
+       -Wno-uninitialized
+       -Wno-reorder-ctor
+       -Wno-logical-op-parentheses
+       -Wno-unused-function
+       -Wno-unknown-pragmas
+    )
   endif()
 
   add_compile_definitions(CUTLASS_ENABLE_SYCL)

--- a/cmake/googlebenchmark.cmake
+++ b/cmake/googlebenchmark.cmake
@@ -45,4 +45,13 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(googlebenchmark)
 
+# Silence warnings from GoogleBenchmark sources
+if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+  foreach(tgt benchmark benchmark_main)
+    if(TARGET ${tgt})
+      target_compile_options(${tgt} PRIVATE -w)
+    endif()
+  endforeach()
+endif()
+
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -44,13 +44,13 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(googletest)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
-  if (TARGET gtest)
-   # Ignore unsupported warning flags on IntelLLVM
-    target_compile_options(gtest PRIVATE -Wno-unknown-warning-option)
-    # Show -Winline warnings, but don’t let them become errors
-    target_compile_options(gtest PRIVATE -Wno-error=inline)
-  endif()
+# Silence warnings from GoogleTest sources
+if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+  foreach(tgt gtest gtest_main gmock gmock_main)
+    if(TARGET ${tgt})
+      target_compile_options(${tgt} PRIVATE -w)
+    endif()
+  endforeach()
 endif()
 
 if (MSVC)


### PR DESCRIPTION
This PR updates the build configuration to compile with stricter warning checks:

-Wall: enables common compiler warnings.

-Werror: treats all warnings as errors, preventing them from being ignored.

-Wno-* suppresses known noisy or irrelevant warnings, so that the build remains strict but practical.

Also all warnings from googletest, googlebenchmark, and compat are silenced.