### PR TITLE
examples: cute: tutorial: use default queue in xe_gemm

### DIFF
--- a/examples/cute/tutorial/xe_gemm.cpp
+++ b/examples/cute/tutorial/xe_gemm.cpp
@@ -391,7 +391,7 @@ int main(int argc, char** argv)
   auto n = parse_size();
   auto k = parse_size();
 
-  sycl::queue Q;
+  sycl::queue Q = compat::get_default_queue();
 
   // Native compute
   test_case<tfloat32_t, tfloat32_t, float, 'R', 'R'>(Q, m, n, k);


### PR DESCRIPTION
The sycl exception will appear when running `xe_gemm` example with `CUTLASS_SYCL_PROFILING_ENABLED=ON` on BMG, now we make this example use default queue to resolve the issue, which sets property `enable_profiling` by default.
```cpp
./examples/cute/tutorial/cute_tutorial_xe_gemm --m 1024 --n 1024 --k 1024
tf32 (R) x tf32 (R) -> float: 
terminate called after throwing an instance of 'sycl::_V1::exception'
  what():  Profiling information is unavailable as the queue associated with the event does not have the 'enable_profiling' property.
Aborted (core dumped)
```