### PR TITLE
Resolve conflict between 572 & 540

### DIFF
--- a/include/cute/atom/copy_traits_xe_2d.hpp
+++ b/include/cute/atom/copy_traits_xe_2d.hpp
@@ -941,6 +941,7 @@ make_block_2d_copy_CD(CopyOp                   const& op,    // Copy operation
                       TiledMMA                 const& mma,   // TiledMMA instance
                       Tensor<GEngine, GLayout> const& gmem)  // Global tensor
 {
+  static_assert(is_xe_block_2d_atom_v<CopyOp>, "Expected a block 2D atom");
   using ValType = typename GEngine::value_type;
   return make_block_2d_copy_CD<ValType>(op, mma, gmem.stride()).with(gmem);
 }


### PR DESCRIPTION
#540 landed first.
#572 had an older base commit than #540's commit when it was merged.
Resolving conflict