### PR TITLE
Add more `static_assert`s in `make_block_2d_copy_CD` to prevent relevant future bugs

### DIFF
--- a/include/cute/atom/copy_traits_xe_2d.hpp
+++ b/include/cute/atom/copy_traits_xe_2d.hpp
@@ -994,7 +994,6 @@ make_block_2d_copy_CD(CopyOp             const& op,          // Copy operation
                       XMode              const& x_mode,      // x, y modes
                       YMode              const& y_mode)
 {
-  static_assert(is_xe_block_2d_atom_v<CopyOp>, "Expected a block 2D atom");
   // Retrieve MMA atom's (subgroup, value) -> (M,N) layout
   auto tile_mn = select<0,1>(mma.tile_mnk());
 


### PR DESCRIPTION
# Summary

`make_block_2d_copy_CD` must not be called with a `void` `CopyOp`, so adding corresponding `static_assert`s to prevent relevant future bugs.
Doesn't solve any current issues, so maybe not high priority, but good to have.

