### PR TITLE
Fixing trD compute type in the Xe Epilogue

### DIFF
--- a/include/cutlass/epilogue/collective/xe_epilogue.hpp
+++ b/include/cutlass/epilogue/collective/xe_epilogue.hpp
@@ -389,7 +389,10 @@ public:
     cst_callbacks.begin();
 
     auto acc_frag = recast<Array<ElementCompute, FragmentSize>>(accumulators);
-    auto trD_compute_frag = recast<Array<ElementCompute, FragmentSize>>(trD_compute);
+    using FragmentVisit = decltype(cst_callbacks.visit(acc_frag(0), 0, 0, 0));
+    constexpr bool IsDirectR2S = cute::is_same_v<FragmentVisit, Array<ElementD, FragmentSize>>;
+    using RegisterElementD = cute::conditional_t<!IsDirectR2S, ElementCompute, ElementD>;
+    auto trD_compute_frag = recast<Array<RegisterElementD, FragmentSize>>(trD_compute);
 
     Tensor trD = make_tensor<ElementOutput>(Shape<Int<FragmentSize>>{});
     auto trD_frag = recast<Array<ElementOutput, FragmentSize>>(trD);
@@ -423,7 +426,7 @@ public:
         if constexpr (is_destination_supported) {
           CUTLASS_PRAGMA_UNROLL
           for (int i = 0; i < size(trD_compute_frag); ++i) {
-            trD_frag(i) = cutlass::NumericArrayConverter<ElementOutput, ElementCompute, FragmentSize>{}(trD_compute_frag(i));
+            trD_frag(i) = cutlass::NumericArrayConverter<ElementOutput, RegisterElementD, FragmentSize>{}(trD_compute_frag(i));
           }
           copy(params.xe_store_d, trD, tCgD(_, epi_m, epi_n));
         }


### PR DESCRIPTION
This PR is to fix the _trD_compute_frag_ type in Xe Epilogue based on the type configured in _cst_callbacks_.

ElementOutput in the LinearCombination and ElementOutput in the CollectiveEpilogue are two different things. 
ElementOutput in CollectiveEpilogue is always same as ElementD, but the ElementOutput in LinearCombination need not to be same as ElementD.

ElementOutput in the LinearCombination represent the output of the LinearCombination operation (alpha*AB, beta*C). 
At the same time, ElementOutput/ElementD in the CollectiveEpilogue represented the actual output which must be stored back.