### PR TITLE
[Xe] [Reorder] Support broadcasting reorders

### DIFF
--- a/include/cute/atom/reorder_atom_xe.hpp
+++ b/include/cute/atom/reorder_atom_xe.hpp
@@ -190,6 +190,7 @@ reorder_impl(ReorderDispatchXeGeneric  const&,
   static constexpr int elems_per_grf = 64 / sizeof(SrcType);
   static constexpr int ds_vl = cute::min(32, cute::min(shape<0>(rlayout), elems_per_grf / stride<0>(rlayout)));
   static constexpr int ss_vl = cute::min(32, cute::min(shape<0>(ilayout), elems_per_grf / stride<0>(ilayout)));
+  static constexpr bool has_broadcast = (size(DLayoutWI{}) > size(SLayoutWI{}));
 
   // Make dst live, to prevent compiler from inserting its own initialization.
 #ifdef __SYCL_DEVICE_ONLY__
@@ -202,7 +203,7 @@ reorder_impl(ReorderDispatchXeGeneric  const&,
   }
 #endif
 
-  if constexpr (ss_vl >= ds_vl) {
+  if constexpr (ss_vl >= ds_vl || has_broadcast) {
     // Stride on src. For simplicity, take 1 GRF at a time.
     for_each(make_seq<size(SLayout{}) / ss_vl>{}, [&](auto i) {
       constexpr auto didx = i * ss_vl;


### PR DESCRIPTION
Adds support for broadcasting in reorders, where a single src value maps to multiple dst values.

This is useful for reordering scales/zero points during dequantization.