### PR TITLE
[Xe] 4-bit unit stride -> VNNI reorders

### DIFF
--- a/examples/cute/tutorial/xe_gemm.cpp
+++ b/examples/cute/tutorial/xe_gemm.cpp
@@ -414,6 +414,7 @@ int main(int argc, char** argv)
   test_case<int4_t, uint8_t, int32_t, 'R', 'C'>(Q, m, n, k);
 
   test_case<uint4_t, uint4_t, uint32_t, 'R', 'C'>(Q, m, n, k);
+  test_case<uint4_t, uint4_t, uint32_t, 'R', 'R'>(Q, m, n, k);
 
   // Upconversion cases
   test_case<half_t, float_e5m2_t, float, 'R', 'R'>(Q, m, n, k);


### PR DESCRIPTION
Adds support for unit -> VNNI reorders for 4-bit types, to enable row-major int4 B.

Note that this is an expensive reorder sequence (9 cycles/register), and it significantly impacts performance for current mainloops. We'll need to enable an SLM-based mainloop to reduce the cost of this reorder.