### PR TITLE
NHD layout

### DIFF
--- a/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
+++ b/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
@@ -312,7 +312,7 @@ template <class FMHAKernel> struct ExampleRunner {
             idx = row * seq_len_kv;
             sum_idx = row;
             for (int col = 0; col < seq_len_kv; col++, idx++) {
-              if(options.is_causal && row < discard_seq_coord) {
+              if (options.is_causal && row < discard_seq_coord) {
                 host_S[idx] = 0;
               } else {
                 host_S[idx] /= sum_vec[sum_idx];


### PR DESCRIPTION
NHD: the last 3 dimensions are organized as (seq_len, num_heads, head_dim).
HND: the last 3 dimensions are organized as (num_heads, seq_len, head_dim).

In VLLM/sglang, NHD is a more commonly used format. Support for NHD has been added in the release pr.