### PR TITLE
Try removing `-DDPCPP_HOST_COMPILER` in CI

### DIFF
--- a/.github/workflows/intel_test_gpp_host.yml
+++ b/.github/workflows/intel_test_gpp_host.yml
@@ -90,8 +90,7 @@ jobs:
             -DIGC_VERSION_MAJOR=${{ matrix.igc_version_major }} \
             -DIGC_VERSION_MINOR=${{ matrix.igc_version_minor }} \
             -DCUTLASS_SYCL_RUNNING_CI=ON \
-            -DCMAKE_CXX_FLAGS="-Werror" \
-            -DDPCPP_HOST_COMPILER=g++-13
+            -DCMAKE_CXX_FLAGS="-Werror -ftemplate-backtrace-limit=0"
           cmake --build .
 
       - name: Unit test


### PR DESCRIPTION
## Description
-DDPCPP_HOST_COMPILER=g++-13 is causing some issues in #600.
Was just checking if icpx worked for everything.

## Type
- [ ] Bug  - [ ] Feature  - [ ] Performance  - [ ] Refactor

## Testing
- [ ] Tests pass  - [ ] Xe12  - [ ] Xe20

## Performance
| Metric | Before | After |
|--------|--------|-------|
|        |        |       |

## References
Fixes #

## Checklist
- [ ] Copyright  - [ ] Co-pilot Review  - [ ] Deprecated APIs not used
