### PR TITLE
[Experiment] Evaluate perf impact of striped vs. blocked SLM read/write 1D copy atoms

### DIFF
--- a/include/cute/arch/copy_xe.hpp
+++ b/include/cute/arch/copy_xe.hpp
@@ -74,7 +74,8 @@ struct XE_1D_LDSM {
       CUTE_STATIC_ASSERT(sizeof(S_) == sizeof(S));
       auto props = sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::contiguous_memory,
-          sycl::ext::oneapi::experimental::alignment<sizeof(D)>};
+          sycl::ext::oneapi::experimental::alignment<sizeof(D)>,
+          sycl::ext::oneapi::experimental::data_placement_striped};
       auto sg =
           sycl::ext::oneapi::this_work_item::get_nd_item<3>().get_sub_group();
       sycl::ext::oneapi::experimental::group_load(
@@ -132,7 +133,8 @@ struct XE_1D_STSM {
       auto sg = sycl::ext::oneapi::this_work_item::get_nd_item<3>().get_sub_group();
       auto props = sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::contiguous_memory,
-          sycl::ext::oneapi::experimental::alignment<sizeof(S)>};
+          sycl::ext::oneapi::experimental::alignment<sizeof(S)>,
+          sycl::ext::oneapi::experimental::data_placement_striped};
       sycl::ext::oneapi::experimental::group_store(
           sg, *reinterpret_cast<sycl::vec<D_, N> const *>(&src), &dst, props);
     #else


### PR DESCRIPTION
## Description

The sycl group/load API used for 1D SLM <-> registers copies support both [blocked & striped](https://github.com/aelizaro/llvm/blob/808d5f395022087352df2e7023d7fa63df8fb2dc/sycl/doc/extensions/proposed/sycl_ext_oneapi_group_load_store.asciidoc#data-placement) copies. For example, `store.slm.d32x4.a32` and `store.slm.d64x2.a32` store 128 bits per work-item (blocked) but cause bank conflicts. Blocked layout is the default data placement for both APIs.

Switching to striped loads & stores (each work-item transfers one item) as an experiment to check performance impact (and any potential breakages). Stores seem to use messages such as `store.slm.d64.a32` or `store.slm.d32x2.a32`, but if the bank width of BMG/PVC is 64 bits (the documentation states 32 bits, but that part may not have been updated for Xe12), then they write to SLM by avoiding bank conflicts. 

Performance characteristics of either type of instructions don't seem to be available in the public domain. It's even possible that the first type may perform better due to fewer block messages (as they transfer twice the data as the instructions of the second type), although they entail bank conflicts. 

Even if we have BF16 data to move to/from SLM, we could reinterpret cast it to a dtype whose size is equal to the width of each lane's bank.

While 1D loads to/from Global Memory also support striped reads/stores, bank conflicts aren't an issue, so I didn't modify the corresponding copy atoms.





## Type
Performance 

## Testing
- [x] Tests pass  - [ ] Xe12  - [ ] Xe20

## Performance
| Metric | Before | After |
|--------|--------|-------|
|        |        |       |

cc @pengzhao-intel
