### PR TITLE
MXFP4/MXFP8/int4 weights support in CuTe interface MoE GEMM example

### DIFF
--- a/examples/12_bmg_moe_gemm_cute_interface/moe_gemms.hpp
+++ b/examples/12_bmg_moe_gemm_cute_interface/moe_gemms.hpp
@@ -72,7 +72,7 @@ template <
 CUTE_DEVICE void moe_gemm(ATensor const &A, // (M,K)
                           BTensor const &B, // (N,K)
                           DTensor &D,       // (M,N)
-                          Coord<int, int, cute::Underscore, int> blk_coord,
+                          Coord<int, int, cute::Underscore, int> &blk_coord,
                           TiledMMA const &mma) {
   auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
   auto local_id = item.get_local_linear_id();
@@ -100,10 +100,10 @@ CUTE_DEVICE void moe_gemm(ATensor const &A, // (M,K)
   auto thr_copy_b = tiled_copy_b.get_slice(local_id);
   auto thr_copy_d = tiled_copy_d.get_slice(local_id);
 
-  auto tCrA = thr_mma.partition_sg_fragment_A(gA(_, _, 0));
-  auto tCrB = thr_mma.partition_sg_fragment_B(gB(_, _, 0));
-  auto tCrD = thr_mma.partition_sg_fragment_C(gD);
-  auto tCrD_final = thr_copy_d.partition_sg_fragment_S(gD);
+  auto tDrA = thr_mma.partition_sg_fragment_A(gA(_, _, 0));
+  auto tDrB = thr_mma.partition_sg_fragment_B(gB(_, _, 0));
+  auto tDrD = thr_mma.partition_sg_fragment_C(gD);
+  auto tDrD_final = thr_copy_d.partition_sg_fragment_S(gD);
 
   auto tArA = thr_copy_a.partition_sg_fragment_D(gA(_, _, 0));
   auto tBrB = thr_copy_b.partition_sg_fragment_D(gB(_, _, 0));
@@ -145,14 +145,227 @@ CUTE_DEVICE void moe_gemm(ATensor const &A, // (M,K)
       prefetch(prefetch_b, pBgB(_, _, _, prefetch_k));
     }
 
-    reorder(tArA, tCrA);
-    reorder(tBrB, tCrB);
+    reorder(tArA, tDrA);
+    reorder(tBrB, tDrB);
 
-    cute::gemm(mma, tCrA, tCrB, tCrD);
+    cute::gemm(mma, tDrA, tDrB, tDrD);
     barrier_wait(barrier_scope);
   }
-  reorder(tCrD, tCrD_final);
-  copy(tiled_copy_d, tCrD_final, tCgD);
+  reorder(tDrD, tDrD_final);
+  copy(tiled_copy_d, tDrD_final, tCgD);
+}
+
+template <class GmemTiledCopyA, class GmemTiledCopyB, class GmemTiledCopyD,
+          int SG_N, int WG_N, int q_group_size, class ATensor, class BTensor,
+          class STensor, class DTensor, class TiledMMA,
+          class = std::enable_if_t<
+              !cute::is_void_v<typename STensor::element_type> &&
+              is_any_of_v<typename BTensor::element_type, float_e2m1_t,
+                          float_e4m3_t, float_e5m2_t, int4_t> &&
+              is_any_of_v<typename STensor::element_type, float_ue8m0_t, half_t,
+                          bfloat16_t> &&
+              is_any_of_v<typename ATensor::element_type, bfloat16_t, half_t>>>
+CUTE_DEVICE void moe_gemm(ATensor const &A, // (M,K)
+                          BTensor const &B, // (N,K)
+                          STensor const &S, // (K/q_group_size, N)
+                          DTensor &D,       // (M,N)
+                          Coord<int, int, cute::Underscore, int> &blk_coord,
+                          TiledMMA const &mma) {
+  auto item = sycl::ext::oneapi::this_work_item::get_nd_item<2>();
+  auto wg_m = int(item.get_group(1));
+  auto wg_n = int(item.get_group(0));
+  auto local_id = int(item.get_local_id(0));
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+  uint32_t sg_id = sg.get_group_linear_id();
+  uint32_t lane = sg.get_local_linear_id();
+
+  auto total_N = get<0>(B.shape());
+
+  Tensor cA = make_identity_tensor(A.shape()); // (M,K)
+  Tensor cB = make_identity_tensor(B.shape()); // (N,K)
+  Tensor cD = make_identity_tensor(D.shape()); // (M,N)
+  Tensor cS = make_identity_tensor(S.shape()); // (K/q_group_size,N)
+  Tensor cScales_per_sg =
+      make_identity_tensor(make_shape(Int<1>{}, Int<SG_N>{}));
+  auto wg_tile = mma.tile_mnk();
+  auto wg_coord = make_coord(wg_m, wg_n, 0);
+
+  Tensor gA = local_tile(cA, select<0, 2>(wg_tile),
+                         make_coord(wg_m, _)); // (BLK_M,BLK_K,k)
+  Tensor gB = local_tile(cB, select<1, 2>(wg_tile),
+                         make_coord(wg_n, _)); // (BLK_N,BLK_K,k)
+  Tensor gD =
+      local_tile(cD, wg_tile, wg_coord, Step<_1, _1, X>{}); // (BLK_M,BLK_N)
+
+  constexpr int num_N_SG_tiles = WG_N / SG_N;
+  constexpr int num_scales_per_col = (SG_N == 32) ? 4 : 2;
+
+  // When we use E8M0, the compiler behaves differently & loads more data than
+  // needed. The rest is discarded.
+  // The scales might be FP16 or BF16 in case of int4 weights
+  using scaleLoadType =
+      conditional_t<is_same_v<typename STensor::element_type, float_ue8m0_t>,
+                    int8_t, int16_t>;
+
+  auto S_tile = coalesce(local_tile(S, make_shape(Int<1>{}, get<1>(wg_tile)),
+                                    make_coord(_, wg_n)));
+
+  auto copy_a = get_block_2d_copy_A<GmemTiledCopyA>(mma, A);
+  auto copy_b = get_block_2d_copy_B<GmemTiledCopyB>(mma, B);
+  auto copy_d = get_block_2d_copy_D<GmemTiledCopyD>(mma, D);
+
+  auto thr_mma = mma.get_slice(local_id);
+  auto thr_copy_a = copy_a.get_slice(local_id);
+  auto thr_copy_b = copy_b.get_slice(local_id);
+  auto thr_copy_d = copy_d.get_slice(local_id);
+
+  auto tDrA = thr_mma.partition_sg_fragment_A(gA(_, _, 0));
+  auto tDrB = thr_mma.partition_sg_fragment_B(gB(_, _, 0));
+
+  auto tArA = thr_copy_a.partition_sg_fragment_D(gA(_, _, 0));
+  auto tBrB = thr_copy_b.partition_sg_fragment_D(gB(_, _, 0));
+  auto tDrD = thr_mma.partition_sg_fragment_C(gD);
+
+  Tensor tAgA = thr_copy_a.partition_S(gA);
+  Tensor tBgB = thr_copy_b.partition_S(gB);
+  Tensor tDgD = thr_copy_d.partition_D(gD);
+
+  auto prefetch_a = make_block_2d_prefetch(copy_a);
+  auto prefetch_b = make_block_2d_prefetch(copy_b);
+
+  auto thr_prefetch_A = prefetch_a.get_slice(local_id);
+  auto thr_prefetch_B = prefetch_b.get_slice(local_id);
+
+  auto pAgA = thr_prefetch_A.partition_S(gA);
+  auto pBgB = thr_prefetch_B.partition_S(gB);
+
+  const int prefetch_dist = 3;
+
+  constexpr int barrier_scope = 2;
+
+  int k_tile_count = ceil_div(shape<1>(A), get<2>(wg_tile));
+  int k_tile_prefetch = 0;
+  constexpr int num_threads_per_sg = 16;
+
+  typename STensor::element_type
+      frag[num_scales_per_col / 2]; // per-thread registers (compiler
+                                    // will keep in regs)
+  float frag_fp32[num_scales_per_col];
+  // assuming SG_K = WG_K
+  constexpr int frequency_scale_change = q_group_size / get<2>(wg_tile);
+  Tensor scales_e8m0 =
+      make_tensor(make_rmem_ptr(frag),
+                  make_layout(make_shape(Int<num_scales_per_col / 2>{})));
+  Tensor scales_float =
+      make_tensor(make_rmem_ptr(frag_fp32),
+                  make_layout(make_shape(Int<num_scales_per_col>{})));
+
+  auto srcTVLayout = make_layout(
+      make_shape(Int<num_threads_per_sg>{}, Int<num_scales_per_col / 2>{}),
+      make_stride(Int<1>{}, Int<num_threads_per_sg>{}));
+  auto dstTVLayout = make_layout(
+      make_shape(make_shape(Int<2>{}, Int<num_threads_per_sg / 2>{}),
+                 make_shape(Int<num_scales_per_col / 2>{})),
+      make_stride(make_stride(Int<0>{}, Int<1>{}), make_stride(Int<8>{})));
+  auto scales_e8m0_sg_tensor = make_subgroup_tensor(scales_e8m0, srcTVLayout);
+  auto scales_float_sg_tensor = make_subgroup_tensor(scales_float, dstTVLayout);
+
+  /* Warm up loops with prefetch to L1 */
+  CUTE_UNROLL
+  for (; k_tile_prefetch < prefetch_dist; k_tile_prefetch++) {
+    prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
+    prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+  }
+  /* Main loop */
+  for (int k_tile = 0; k_tile < k_tile_count; k_tile++, k_tile_prefetch++) {
+    barrier_arrive(barrier_scope);
+    copy(copy_b, tBgB(_, _, _, k_tile), tBrB);
+    prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+    reorder(tBrB, tDrB);
+
+    if (k_tile % frequency_scale_change == 0) {
+      auto scales_tensor = make_tensor(
+          make_gmem_ptr(reinterpret_cast<scaleLoadType *>(
+              static_cast<void *>(cute::raw_pointer_cast(
+                  S_tile.data() + (SG_N * (sg_id % num_N_SG_tiles)) +
+                  (k_tile / frequency_scale_change) * total_N)))),
+          make_layout(make_shape(Int<1>{}, Int<SG_N>{})));
+      auto copy_scales = make_block_2d_copy(
+          XE_LOAD_2D<sizeof_bits_v<typename STensor::element_type>, 1, SG_N,
+                     SG_N>{},
+          scales_tensor);
+      auto thr_copy_scales = copy_scales.get_slice(lane);
+      auto scales_per_thread = thr_copy_scales.partition_S(cScales_per_sg);
+      copy(copy_scales, scales_per_thread(_, 0, 0), scales_e8m0);
+      reorder(scales_e8m0_sg_tensor, scales_float_sg_tensor);
+      if (k_tile != (k_tile_count - frequency_scale_change)) {
+        auto next_scales_tensor = make_tensor(
+            make_gmem_ptr(reinterpret_cast<scaleLoadType *>(
+                static_cast<void *>(cute::raw_pointer_cast(
+                    S_tile.data() + (SG_N * (sg_id % num_N_SG_tiles)) +
+                    ((k_tile / frequency_scale_change) + 1) * total_N)))),
+            make_layout(make_shape(Int<1>{}, Int<SG_N>{})));
+        auto prefetch_scales = make_block_2d_prefetch<1>(
+            make_shape(Int<1>{}, Int<SG_N>{}), next_scales_tensor);
+        auto thr_prefetch_scales = prefetch_scales.get_slice(lane);
+        auto pSgS = thr_prefetch_scales.partition_S(cScales_per_sg);
+        prefetch(prefetch_scales, pSgS(_, 0, 0));
+      }
+    }
+    copy(copy_a, tAgA(_, _, _, k_tile), tArA);
+    prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
+    reorder(tArA, tDrA);
+    // Instead of hardcoding, figure out CuTe algebra based
+    // transformations that can lead to generic code.
+    auto scale0 = scales_float_sg_tensor[0];
+    auto scale1 = scales_float_sg_tensor[1];
+    if (num_scales_per_col == 4) {
+      auto scale2 = scales_float_sg_tensor[2];
+      auto scale3 = scales_float_sg_tensor[3];
+      CUTE_UNROLL
+      for (int i = 0; i < 16; i += 2) {
+        tDrB[i] = static_cast<typename ATensor::element_type>(
+            scale0 * static_cast<float>(tDrB[i]));
+        tDrB[i + 1] = static_cast<typename ATensor::element_type>(
+            scale1 * static_cast<float>(tDrB[i + 1]));
+      }
+      CUTE_UNROLL
+      for (int i = 16; i < 32; i += 2) {
+        tDrB[i] = static_cast<typename ATensor::element_type>(
+            scale2 * static_cast<float>(tDrB[i]));
+        tDrB[i + 1] = static_cast<typename ATensor::element_type>(
+            scale3 * static_cast<float>(tDrB[i + 1]));
+      }
+      CUTE_UNROLL
+      for (int i = 32; i < 48; i += 2) {
+        tDrB[i] = static_cast<typename ATensor::element_type>(
+            scale0 * static_cast<float>(tDrB[i]));
+        tDrB[i + 1] = static_cast<typename ATensor::element_type>(
+            scale1 * static_cast<float>(tDrB[i + 1]));
+      }
+      CUTE_UNROLL
+      for (int i = 48; i < 64; i += 2) {
+        tDrB[i] = static_cast<typename ATensor::element_type>(
+            scale2 * static_cast<float>(tDrB[i]));
+        tDrB[i + 1] = static_cast<typename ATensor::element_type>(
+            scale3 * static_cast<float>(tDrB[i + 1]));
+      }
+    } else {
+      CUTE_UNROLL
+      for (int i = 0; i < 32; i += 2) {
+        tDrB[i] = static_cast<typename ATensor::element_type>(
+            scale0 * static_cast<float>(tDrB[i]));
+        tDrB[i + 1] = static_cast<typename ATensor::element_type>(
+            scale1 * static_cast<float>(tDrB[i + 1]));
+      }
+    }
+
+    gemm(mma, tDrA, tDrB, tDrD);
+    barrier_wait(barrier_scope);
+  }
+  auto tDrD_final = thr_copy_d.partition_sg_fragment_S(gD);
+  reorder(tDrD, tDrD_final);
+  copy(copy_d, tDrD_final, tDgD);
 }
 
 } // namespace MoE

--- a/examples/12_bmg_moe_gemm_cute_interface/moe_grouped_gemm.hpp
+++ b/examples/12_bmg_moe_gemm_cute_interface/moe_grouped_gemm.hpp
@@ -127,7 +127,6 @@ MoEGEMM(const ElementA *Activations, const ElementB *Weights,
       did_group_change = false;
     }
 
-    // After adding scaledMM mainloops, add something like
     if constexpr (!cute::is_void_v<ElementS>) {
       moe_gemm<GmemTiledCopyA, GmemTiledCopyB, GmemTiledCopyD, SG_N, WG_N,
                q_group_size>(A_tensor, B_tensor, Scales, D_tensor, tile_coord,

--- a/examples/12_bmg_moe_gemm_cute_interface/moe_tile_scheduler.hpp
+++ b/examples/12_bmg_moe_gemm_cute_interface/moe_tile_scheduler.hpp
@@ -54,8 +54,8 @@ class PersistentTileSchedulerXeMoE
   //
 
 private:
-  uint64_t current_work_linear_idx_ = 0;
-  uint64_t total_grid_size_ = 0;
+  uint32_t current_work_linear_idx_ = 0;
+  uint32_t total_grid_size_ = 0;
   int32_t *num_rows_per_expert_ = nullptr;
   int32_t K_ = 0;
   int32_t N_ = 0;
@@ -64,8 +64,8 @@ private:
   // Tracking current group, its starting linear idx and total tiles
   struct GroupInfo {
     int group_idx = 0;
-    uint64_t start_linear_idx = 0;
-    uint64_t total_tiles = 0;
+    uint32_t start_linear_idx = 0;
+    uint32_t total_tiles = 0;
   } current_group_info_;
 
 public:
@@ -148,13 +148,13 @@ public:
     num_experts_ = num_experts;
     if (scheduler_params.raster_order_ == RasterOrder::AlongN) {
       current_work_linear_idx_ =
-          uint64_t(BlockIdxX()) + uint64_t(BlockIdxY()) * uint64_t(GridDimX());
+          uint32_t(BlockIdxX()) + uint32_t(BlockIdxY()) * uint32_t(GridDimX());
     } else {
       current_work_linear_idx_ =
-          uint64_t(BlockIdxX()) * uint64_t(GridDimY()) + uint64_t(BlockIdxY());
+          uint32_t(BlockIdxX()) * uint32_t(GridDimY()) + uint32_t(BlockIdxY());
     }
     total_grid_size_ =
-        uint64_t(GridDimX()) * uint64_t(GridDimY()) * uint64_t(GridDimZ());
+        uint32_t(GridDimX()) * uint32_t(GridDimY()) * uint32_t(GridDimZ());
   }
 
   CUTLASS_DEVICE
@@ -163,7 +163,7 @@ public:
   }
 
   CUTLASS_DEVICE
-  WorkTileInfo get_current_work_for_linear_idx(uint64_t linear_idx) {
+  WorkTileInfo get_current_work_for_linear_idx(uint32_t linear_idx) {
     return get_work_idx_m_and_n(
         linear_idx, current_group_info_, scheduler_params.problem_shapes_,
         scheduler_params.cta_shape_, scheduler_params.cluster_shape_,
@@ -176,13 +176,13 @@ public:
 
   CUTLASS_DEVICE
   void advance_to_next_work(uint32_t advance_count = 1) {
-    current_work_linear_idx_ += total_grid_size_ * uint64_t(advance_count);
+    current_work_linear_idx_ += total_grid_size_ * uint32_t(advance_count);
   }
 
   // get work_idx_m, work_idx_n from linear_idx while applying swizzle
   CUTLASS_DEVICE
   WorkTileInfo
-  get_work_idx_m_and_n(uint64_t linear_idx, struct GroupInfo &group_info,
+  get_work_idx_m_and_n(uint32_t linear_idx, struct GroupInfo &group_info,
                        GroupProblemShape &problem_shapes, GemmCoord cta_shape,
                        cutlass::gemm::GemmCoord cluster_shape,
                        FastDivmodU64Pow2 const &divmod_cluster_shape_major,
@@ -192,21 +192,10 @@ public:
                        int32_t log_swizzle_size, RasterOrder raster_order) {
 
     bool valid_tile = true;
-    uint64_t ctas_along_m, ctas_along_n;
     int total_problem_groups = num_experts_;
-    ctas_along_m = divmod_cta_shape_m.divide(
-        cute::shape<0>(
-            ProblemShape(num_rows_per_expert_[group_info.group_idx], N_, K_)) +
-        divmod_cta_shape_m.divisor - 1);
-    ctas_along_n = divmod_cta_shape_n.divide(
-        cute::shape<1>(
-            ProblemShape(num_rows_per_expert_[group_info.group_idx], N_, K_)) +
-        divmod_cta_shape_n.divisor - 1);
-
-    auto problem_blocks_m =
-        round_up(ctas_along_m, (1 << log_swizzle_size) * cluster_shape.m());
-    auto problem_blocks_n =
-        round_up(ctas_along_n, (1 << log_swizzle_size) * cluster_shape.n());
+    auto problem_blocks_m =  (cute::shape<0>(ProblemShape(
+              num_rows_per_expert_[group_info.group_idx], N_, K_)) + cta_shape.m() - 1) / cta_shape.m();
+    auto problem_blocks_n =  (N_ + cta_shape.n() - 1) / cta_shape.n();
     group_info.total_tiles = problem_blocks_m * problem_blocks_n;
 
     while (group_info.start_linear_idx + group_info.total_tiles <= linear_idx) {
@@ -216,72 +205,16 @@ public:
         return WorkTileInfo::invalid_work_tile();
 
       group_info.start_linear_idx += group_info.total_tiles;
-      ctas_along_m = divmod_cta_shape_m.divide(
-          cute::shape<0>(ProblemShape(
-              num_rows_per_expert_[group_info.group_idx], N_, K_)) +
-          divmod_cta_shape_m.divisor - 1);
-      ctas_along_n = divmod_cta_shape_n.divide(
-          cute::shape<1>(ProblemShape(
-              num_rows_per_expert_[group_info.group_idx], N_, K_)) +
-          divmod_cta_shape_n.divisor - 1);
-
-      problem_blocks_m =
-          round_up(ctas_along_m, (1 << log_swizzle_size) * cluster_shape.m());
-      problem_blocks_n =
-          round_up(ctas_along_n, (1 << log_swizzle_size) * cluster_shape.n());
+      problem_blocks_m =  (cute::shape<0>(ProblemShape(
+              num_rows_per_expert_[group_info.group_idx], N_, K_)) + cta_shape.m() - 1) / cta_shape.m();
+      problem_blocks_n =  (N_ + cta_shape.n() - 1) / cta_shape.n();
       group_info.total_tiles = problem_blocks_m * problem_blocks_n;
     }
-
-    uint64_t cluster_id, cluster_major_offset = 0, cluster_minor_offset = 0;
-    uint64_t blk_per_grid_dim = divmod_cluster_shape_minor.divide(
-        linear_idx - group_info.start_linear_idx);
-    divmod_cluster_shape_major(cluster_id, cluster_major_offset,
-                               blk_per_grid_dim);
-
-    // With static schedulers, we launch grid such that all cluster are linear
-    // (1-D) order, i.e., there can only be one cluster in the minor dimension.
-    // get_grid_shape() in scheduler params put cluster_shape.m/n() as the minor
-    // dimension based on raster order AlongN/M resp. Therefore, the offset of a
-    // CTA (inside a cluster) in the minor dimension can be directly be inferred
-    // by the blockIdx along the minor dimension.
+    uint32_t diff_from_linear_idx = linear_idx - group_info.start_linear_idx;
     if (raster_order == RasterOrder::AlongN) {
-      cluster_minor_offset = BlockIdxX();
+      return {static_cast<int32_t>(diff_from_linear_idx / problem_blocks_n + BlockIdxX()), static_cast<int32_t>(diff_from_linear_idx % problem_blocks_n), group_info.group_idx, valid_tile};
     } else {
-      cluster_minor_offset = BlockIdxY();
-    }
-
-    uint64_t cluster_idx_minor, cluster_idx_major;
-
-    uint64_t cluster_idx_minor_div_swizzle, extra, offset;
-
-    offset = cluster_id & ((1 << log_swizzle_size) - 1);
-    extra = cluster_id >> log_swizzle_size;
-
-    uint64_t curr_group_cluster_blk_major;
-    if (raster_order == RasterOrder::AlongN) {
-      curr_group_cluster_blk_major =
-          divmod_cluster_shape_major.divide(problem_blocks_n);
-    } else {
-      curr_group_cluster_blk_major =
-          divmod_cluster_shape_major.divide(problem_blocks_m);
-    }
-    cluster_idx_minor_div_swizzle = extra / curr_group_cluster_blk_major;
-    cluster_idx_major = extra % curr_group_cluster_blk_major;
-
-    cluster_idx_minor =
-        cluster_idx_minor_div_swizzle * (1 << log_swizzle_size) + offset;
-
-    auto minor_work_idx = static_cast<int32_t>(
-        cluster_idx_minor * divmod_cluster_shape_minor.divisor +
-        cluster_minor_offset);
-    auto major_work_idx = static_cast<int32_t>(
-        cluster_idx_major * divmod_cluster_shape_major.divisor +
-        cluster_major_offset);
-
-    if (raster_order == RasterOrder::AlongN) {
-      return {minor_work_idx, major_work_idx, group_info.group_idx, valid_tile};
-    } else {
-      return {major_work_idx, minor_work_idx, group_info.group_idx, valid_tile};
+      return {static_cast<int32_t>(diff_from_linear_idx % problem_blocks_m), static_cast<int32_t>(diff_from_linear_idx / problem_blocks_m + BlockIdxY()), group_info.group_idx, valid_tile};
     }
   }
 


### PR DESCRIPTION
## Summary

Adds MoE GEMM implementation for MXFP4/MXFP8 (FP4/FP8 weights & E8M0 scales, with group-wise quantization) with CuTe interface.
If users don't select copy atoms for loading activations, weights & storing output, then they would be chosen automatically. Users can pass void as corresponding copy atom template parameters, but the copy atoms chosen automatically may not not always attain the best performance, so users can specify custom copy atoms.

Support for int4 weights with BF16/FP16 scales has also been added.

Weights are in plain format, and have not been prepacked.

## Details 

BMG doesn't support MXFP4/MXFP8/int4 natively, so it's converted to either FP16 or BF16, depending upon the activation.

Currently, it assumes WG_K & SG_K are both equal to 32.


## Performance
Largely depends upon scaledMM performance in #633


cc @CaoZhongZ @mayuyuace @pengzhao-Intel
