### PR TITLE
Enable XeTopologicalVisitor for python EVT UT

### DIFF
--- a/include/cutlass/epilogue/fusion/sm90_visitor_tma_warpspecialized.hpp
+++ b/include/cutlass/epilogue/fusion/sm90_visitor_tma_warpspecialized.hpp
@@ -748,6 +748,15 @@ struct Sm90TopologicalVisitor : Sm90VisitorImpl<Ops...> {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
+// Alias for Xe
+template<class ElementCompute, class EdgeTuple, class... Ops>
+using Xe20TopologicalVisitor = Sm90TopologicalVisitor<ElementCompute, EdgeTuple, Ops...>;
+
+template<class ElementCompute, class EdgeTuple, class... Ops>
+using Xe12TopologicalVisitor = Sm90TopologicalVisitor<ElementCompute, EdgeTuple, Ops...>;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
 // Base specializations so we can have standard layout params and simple aggregate initializers
 namespace detail {
 

--- a/python/cutlass_cppgen/backend/evt/backend/emitter_base.py
+++ b/python/cutlass_cppgen/backend/evt/backend/emitter_base.py
@@ -125,16 +125,16 @@ class FusionCallbacks:
         subgraph_nodes = subgraph.nodes_topological_order()
         # Emit the Edge Tuple
         edge_tuples = "cute::tuple<\n"
+        edge_tuple_list = []
         for n in subgraph_nodes[:-1]:
             in_edges = subgraph.in_edges(n)
             edge_weights = [subgraph.get_edge_weight(edge[0], edge[1]) for edge in in_edges]
             sorted_children = [edge[0] for _, edge in sorted(zip(edge_weights, in_edges))]
             edge_tuple = "        cute::seq<"
             edge_str = [str(subgraph_nodes.index(child)) for child in sorted_children]
-            edge_tuple += ", ".join(edge_str) + ">,\n"
-
-            edge_tuples += edge_tuple
-        edge_tuples += "    >"
+            edge_tuple += ", ".join(edge_str) + ">"
+            edge_tuple_list.append(edge_tuple)
+        edge_tuples += ",\n".join(edge_tuple_list) + "\n    >"
 
         # Emit the node list
         dag_nodes = ""
@@ -147,13 +147,22 @@ class FusionCallbacks:
                 dag_node_strs.append(f"    {n_meta.name_camel}")
         dag_nodes = ",\n".join(dag_node_strs)
 
-        return f"""
-using {node.name_camel} = cutlass::epilogue::{self.namespace}::Sm{self.evt_cc}TopologicalVisitor<
-    {DataTypeTag[node.subgraph.element_compute]},
-    {edge_tuples},
-{dag_nodes}
->;
-"""
+        if self.cc in [INTEL_XE12, INTEL_XE20]:  
+            return f"""
+            using {node.name_camel} = cutlass::epilogue::{self.namespace}::Xe{self.evt_cc}TopologicalVisitor<
+                {DataTypeTag[node.subgraph.element_compute]},
+                {edge_tuples},
+            {dag_nodes}
+            >;
+            """
+        else:
+            return f"""
+            using {node.name_camel} = cutlass::epilogue::{self.namespace}::Sm{self.evt_cc}TopologicalVisitor<
+                {DataTypeTag[node.subgraph.element_compute]},
+                {edge_tuples},
+            {dag_nodes}
+            >;
+            """
 
     def emit_node(self, node):
         if isinstance(node, TopoVisitorNode):

--- a/python/cutlass_cppgen/backend/evt/backend/xe12_nodes.py
+++ b/python/cutlass_cppgen/backend/evt/backend/xe12_nodes.py
@@ -31,7 +31,7 @@
 
 from pycute import product
 
-from cutlass_library import DataTypeSize, DataTypeTag
+from cutlass_library import DataType, DataTypeSize, DataTypeTag
 from cutlass_cppgen.backend.evt.ir import (
     # Load Node
     AccumulatorImpl,
@@ -57,6 +57,14 @@ from cutlass_cppgen.backend.library import (
     FunctionalOp,
     op_tag,
 )
+
+ATOMIC_GMEM_OPS = {FunctionalOp.AtomicAdd, FunctionalOp.AtomicMaximum}
+
+def _needs_atomic_float(element_dtype, gmem_reduce_fn):
+    return (
+        gmem_reduce_fn in ATOMIC_GMEM_OPS and
+        element_dtype in (DataType.f16, DataType.bf16)
+    )
 
 
 class xe12AccumulatorImpl(AccumulatorImpl):
@@ -266,6 +274,14 @@ using StrideD = {self.stride_mnl};
 
 class xe12ColumnReductionImpl(ColumnReductionImpl):
 
+    def __init__(self, node) -> None:
+      super().__init__(node)
+      if _needs_atomic_float(self.element, self.gmem_reduce_fn):
+            raise RuntimeError(
+                f"Xe12 column reduction '{self.name}' uses {DataTypeTag[self.element]} with {op_tag(self.gmem_reduce_fn)}, "
+                "which requires a float output because sycl::atomic_ref does not support half/bfloat16. Please declare the reduction tensor as float32."
+            )
+
     @property
     def type_decl(self):
         """
@@ -286,6 +302,14 @@ using {self.name_camel} = cutlass::epilogue::fusion::Sm90ColReduction<
 
 
 class xe12RowReductionImpl(RowReductionImpl):
+
+    def __init__(self, node) -> None:
+        super().__init__(node)
+        if _needs_atomic_float(self.element, self.gmem_reduce_fn):
+            raise RuntimeError(
+                f"Xe12 row reduction '{self.name}' uses {DataTypeTag[self.element]} with {op_tag(self.gmem_reduce_fn)}, "
+                "which requires a float output because sycl::atomic_ref does not support half/bfloat16. Please declare the reduction tensor as float32."
+            )
 
 
     @property
@@ -308,6 +332,14 @@ using {self.name_camel} = cutlass::epilogue::fusion::Sm90RowReduction<
 
 
 class xe12ScalarReductionImpl(ScalarReductionImpl):
+
+    def __init__(self, node) -> None:
+        super().__init__(node)
+        if _needs_atomic_float(self.element, self.gmem_reduce_fn):
+            raise RuntimeError(
+                f"Xe12 scalar reduction '{self.name}' uses {DataTypeTag[self.element]} with {op_tag(self.gmem_reduce_fn)}, "
+                "which requires a float output because sycl::atomic_ref does not support half/bfloat16. Please declare the reduction tensor as float32."
+            )
 
 
     @property

--- a/python/cutlass_cppgen/backend/evt/backend/xe20_nodes.py
+++ b/python/cutlass_cppgen/backend/evt/backend/xe20_nodes.py
@@ -31,7 +31,7 @@
 
 from pycute import product
 
-from cutlass_library import DataTypeSize, DataTypeTag
+from cutlass_library import DataType, DataTypeSize, DataTypeTag
 from cutlass_cppgen.backend.evt.ir import (
     # Load Node
     AccumulatorImpl,
@@ -57,6 +57,15 @@ from cutlass_cppgen.backend.library import (
     FunctionalOp,
     op_tag,
 )
+
+ATOMIC_GMEM_OPS = {FunctionalOp.AtomicAdd, FunctionalOp.AtomicMaximum}
+
+def _needs_atomic_float(element_dtype, gmem_reduce_fn):
+    return (
+        gmem_reduce_fn in ATOMIC_GMEM_OPS and
+        element_dtype in (DataType.f16, DataType.bf16)
+    )
+
 
 
 class xe20AccumulatorImpl(AccumulatorImpl):
@@ -266,6 +275,14 @@ using StrideD = {self.stride_mnl};
 
 class xe20ColumnReductionImpl(ColumnReductionImpl):
 
+    def __init__(self, node) -> None:
+      super().__init__(node)
+      if _needs_atomic_float(self.element, self.gmem_reduce_fn):
+            raise RuntimeError(
+                f"Xe20 column reduction '{self.name}' uses {DataTypeTag[self.element]} with {op_tag(self.gmem_reduce_fn)}, "
+                "which requires a float output because sycl::atomic_ref does not support half/bfloat16. Please declare the reduction tensor as float32."
+            )
+      
     @property
     def type_decl(self):
         """
@@ -287,6 +304,13 @@ using {self.name_camel} = cutlass::epilogue::fusion::Sm90ColReduction<
 
 class xe20RowReductionImpl(RowReductionImpl):
 
+    def __init__(self, node) -> None:
+        super().__init__(node)
+        if _needs_atomic_float(self.element, self.gmem_reduce_fn):
+            raise RuntimeError(
+                f"Xe20 row reduction '{self.name}' uses {DataTypeTag[self.element]} with {op_tag(self.gmem_reduce_fn)}, "
+                "which requires a float output because sycl::atomic_ref does not support half/bfloat16. Please declare the reduction tensor as float32."
+            )
 
     @property
     def type_decl(self):
@@ -309,6 +333,13 @@ using {self.name_camel} = cutlass::epilogue::fusion::Sm90RowReduction<
 
 class xe20ScalarReductionImpl(ScalarReductionImpl):
 
+    def __init__(self, node) -> None:
+        super().__init__(node)
+        if _needs_atomic_float(self.element, self.gmem_reduce_fn):
+            raise RuntimeError(
+                f"Xe20 scalar reduction '{self.name}' uses {DataTypeTag[self.element]} with {op_tag(self.gmem_reduce_fn)}, "
+                "which requires a float output because sycl::atomic_ref does not support half/bfloat16. Please declare the reduction tensor as float32."
+            )
 
     @property
     def type_decl(self):

--- a/test/python/cutlass/evt/evt_store_sm80_90.py
+++ b/test/python/cutlass/evt/evt_store_sm80_90.py
@@ -46,10 +46,10 @@ from utils.evt_testbed import EVTTestBed, EVTTestCaseBase
 cutlass_cppgen.set_log_level(logging.WARNING)
 
 
-@unittest.skipIf(device_cc() not in [80, 86, 89, 90], "This unittest is only supported on CC [80, 86, 89, 90]")
+@unittest.skipIf(device_cc() not in [12, 20, 80, 86, 89, 90], "This unittest is only supported on CC [12, 20, 80, 86, 89, 90]")
 class TestEVTStore(EVTTestCaseBase):
 
-    @unittest.skipIf(device_cc() != 90, "This test is only for CC 90")
+    @unittest.skipIf(device_cc() not in [12, 20, 90], "This test is only supported on CC [12, 20, 90]")
     def test_invalid_store(self):
         """
         Test invalid store
@@ -174,6 +174,39 @@ class TestEVTStore(EVTTestCaseBase):
             input_keys = ["C", "alpha"]
             result_keys = ["D", "F_max", "acc_max"]
             launcher.verify((m, n, k), input_keys, result_keys, l)
+
+    def test_store_with_multiple_reductions(self):
+        """
+        Test storing main output with multiple types of reductions
+        """
+        def evt_store_multi_reduce(accum, alpha, beta, C):
+            F = alpha * accum + beta * C
+            
+            # Multiple reduction types
+            row_max = max(F, dim=[2,])      # [l, m, 1]
+            col_max = max(F, dim=[1,])      # [l, 1, n] 
+            scalar_max = max(F, dim=[1, 2]) # [l, 1, 1]
+            
+            D = F + C
+            return D, row_max, col_max, scalar_max
+
+        for m, n, k, l in self.get_problem_sizes(8):
+            example_inputs = {
+                "accum": self.fake_tensor(self.element, (l, m, n)),
+                "alpha": 2.0,
+                "beta": 0.5,
+                "C": self.fake_tensor(self.element, (l, m, n)),
+                "D": self.fake_tensor(self.element, (l, m, n)),
+                "row_max": self.fake_tensor(np.float32, (l, m, 1)),
+                "col_max": self.fake_tensor(np.float32, (l, 1, n)),
+                "scalar_max": self.fake_tensor(np.float32, (l, 1, 1)),
+            }
+
+            launcher = EVTTestBed(self.element, evt_store_multi_reduce, example_inputs)
+            input_keys = ["C", "alpha", "beta"]
+            result_keys = ["D", "row_max", "col_max", "scalar_max"]
+            launcher.verify((m, n, k), input_keys, result_keys, l)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
New EVT UT test_store_with_multiple_reductions was failing because TopologicalVisitor not enabled for xe20/12. Changes in this PR enables the same. Also added checks to prevent user using half_t  for atomic reductions as sycl::atomic_ref has not support for half_t yet. This came to notice when we tried row_max, col_max and scalar_max with half precision datatype. 

Note : This PR depends on https://github.com/intel/sycl-tla/pull/680