### PR TITLE
Enable python AuxStore UT

### DIFF
--- a/python/cutlass_cppgen/backend/evt/backend/xe12_nodes.py
+++ b/python/cutlass_cppgen/backend/evt/backend/xe12_nodes.py
@@ -219,22 +219,6 @@ using {self.name_camel} = cutlass::epilogue::fusion::Xe12Compute<
 class xe12AuxStoreImpl(AuxStoreImpl):
 
     @property
-    def descriptor(self) -> str:
-        """
-        Descriptor for Aux Load
-        """
-        return f"{self.name_camel}Descriptor"
-
-    def decl_descriptor(self) -> str:
-        """
-        Declare the descriptor type
-        """
-        return f"""
-using {self.descriptor} = cutlass::epilogue::collective::detail::AuxStoreDescriptor<
-    EpilogueDescriptor, {self.stride_mnl}, {DataTypeTag[self.element]}
->;
-"""
-    @property
     def type_decl(self):
         """
         Return the string defining the type
@@ -242,21 +226,13 @@ using {self.descriptor} = cutlass::epilogue::collective::detail::AuxStoreDescrip
         if self._type_decl is not None:
             return self._type_decl
 
-        self._type_decl = self.decl_descriptor()
-        self._type_decl += f"""
-using {self.name_camel} = cutlass::epilogue::fusion::Sm90AuxStore<
-    {self.descriptor}::Stages, typename {self.descriptor}::EpilogueTile, {DataTypeTag[self.element]},
-    {FloatRoundStyleTag[self.round_style]}, {self.stride_mnl}, typename {self.descriptor}::SmemLayoutAtom,
-    typename {self.descriptor}::CopyOpR2S
+        self._type_decl = f"""
+using {self.name_camel} = cutlass::epilogue::fusion::XeAuxStore<
+    {DataTypeTag[self.element]},
+    {self.stride_mnl}
 >;
 """
         return self._type_decl
-
-    def get_smem_size(self, cta_tile_mnk, epilogue_tile_mn, stages_c, stages_d, epi_tiles):
-        """
-        Get the shared memory size based on epilogue_tile_mn, stages_c, and stages_d
-        """
-        return (DataTypeSize[self.element] * stages_d * product(epilogue_tile_mn) // 8, 128)
 
 
 class xe12StoreDImpl(StoreDImpl):

--- a/python/cutlass_cppgen/backend/evt/backend/xe20_nodes.py
+++ b/python/cutlass_cppgen/backend/evt/backend/xe20_nodes.py
@@ -220,22 +220,6 @@ using {self.name_camel} = cutlass::epilogue::fusion::Xe20Compute<
 class xe20AuxStoreImpl(AuxStoreImpl):
 
     @property
-    def descriptor(self) -> str:
-        """
-        Descriptor for Aux Load
-        """
-        return f"{self.name_camel}Descriptor"
-
-    def decl_descriptor(self) -> str:
-        """
-        Declare the descriptor type
-        """
-        return f"""
-using {self.descriptor} = cutlass::epilogue::collective::detail::AuxStoreDescriptor<
-    EpilogueDescriptor, {self.stride_mnl}, {DataTypeTag[self.element]}
->;
-"""
-    @property
     def type_decl(self):
         """
         Return the string defining the type
@@ -243,21 +227,13 @@ using {self.descriptor} = cutlass::epilogue::collective::detail::AuxStoreDescrip
         if self._type_decl is not None:
             return self._type_decl
 
-        self._type_decl = self.decl_descriptor()
-        self._type_decl += f"""
-using {self.name_camel} = cutlass::epilogue::fusion::Sm90AuxStore<
-    {self.descriptor}::Stages, typename {self.descriptor}::EpilogueTile, {DataTypeTag[self.element]},
-    {FloatRoundStyleTag[self.round_style]}, {self.stride_mnl}, typename {self.descriptor}::SmemLayoutAtom,
-    typename {self.descriptor}::CopyOpR2S
+        self._type_decl = f"""
+using {self.name_camel} = cutlass::epilogue::fusion::XeAuxStore<
+    {DataTypeTag[self.element]},
+    {self.stride_mnl}
 >;
 """
         return self._type_decl
-
-    def get_smem_size(self, cta_tile_mnk, epilogue_tile_mn, stages_c, stages_d, epi_tiles):
-        """
-        Get the shared memory size based on epilogue_tile_mn, stages_c, and stages_d
-        """
-        return (DataTypeSize[self.element] * stages_d * product(epilogue_tile_mn) // 8, 128)
 
 
 class xe20StoreDImpl(StoreDImpl):

--- a/python/cutlass_cppgen/backend/evt/ir/store_nodes.py
+++ b/python/cutlass_cppgen/backend/evt/ir/store_nodes.py
@@ -94,14 +94,18 @@ class AuxStoreImpl(StoreImplBase):
         stride_mnl = self.get_stride_mnl()
         name = self.name
         tuple_type = tuple_factory(stride_mnl, self.stride_dtype)
+        element_type = self.element
+        null_default = to_ctype_value(0, element_type)
         class _Argument(ctypes.Structure):
             _fields_ = [
                 ("ptr_aux", ctypes.c_void_p),
+                ("null_default", dtype2ctype[element_type]),
                 ("dAux", tuple_type)
             ]
             def __init__(self, kwargs) -> None:
                 ptr = kwargs[name]
                 self.ptr_aux = ptr
+                self.null_default = null_default
                 self.dAux = tuple_type(stride_mnl)
 
         return _Argument


### PR DESCRIPTION
This PR include changes to run test_aux_store() but this PR depends on https://github.com/intel/sycl-tla/pull/691.

Without this change test_aux_store() was failing with 'device lost" error because its EVT visitor argument didn't match C++ ABI: XeAuxStore::Arguments on the host has three consecutive members: ptr_aux, null_default, dAux but our ctypes had only encoded the pointer and strides. That made the visitor struct 8 bytes small shifting every subsequent offset (so ptr_C/ptr_D got 64/88 instead of 72/96) and causing the host code to read 0x8 for both pointers. Adding the missing null_default field to AuxStoreImpl.argument_type restores the exact byte layout so the computed offsets align with C++ and the aux-store test able to see the real C/D addresses.