### PR TITLE
Fix CMake path issue

### DIFF
--- a/tools/util/CMakeLists.txt
+++ b/tools/util/CMakeLists.txt
@@ -29,7 +29,7 @@ cmake_policy(SET CMP0112 NEW)
 
 # Include oneMKL support for SYCL builds
 if (CUTLASS_ENABLE_SYCL)
-  include(${CMAKE_SOURCE_DIR}/cmake/onemkl.cmake)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/onemkl.cmake)
 endif()
 
 add_library(cutlass_tools_util_includes INTERFACE)


### PR DESCRIPTION
If sycl-tla is the topmost project, ${CMAKE_SOURCE_DIR} refers to its root folder path. But, if sycl-tla is used by the topmost project, ${CMAKE_SOURCE_DIR} refers to the topmost project path. ${CMAKE_CURRENT_SOURCE_DIR} refers to this file's path.
