### PR TITLE
Refine Flash Attention and fix bugs

### DIFF
--- a/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
+++ b/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
@@ -258,8 +258,8 @@ template <class FMHAKernel, bool isVarLen = false> struct ExampleRunner {
 
     // Use Cacheline Size to calculate alignment
     constexpr int cacheline_bytes = 64;
-    constexpr int AlignmentQ = cacheline_bytes / sizeof(ElementQ);    // Alignment of Q matrix in units of elements
-    constexpr int AlignmentKV = cacheline_bytes / sizeof(ElementK);   // Alignment of Kand V matrix in units of elements
+    constexpr int AlignmentQ = cacheline_bytes * 8 /  sizeof_bits_v<ElementQ> ;    // Alignment of Q matrix in units of elements
+    constexpr int AlignmentKV = cacheline_bytes * 8 / sizeof_bits_v<ElementK> ;   // Alignment of Kand V matrix in units of elements
     constexpr int AlignmentKVCache = 128; //Page size must be a multiple of 128
     auto generate_positive_int = [](auto& dist, auto& gen) {
       int result = 0;
@@ -624,7 +624,7 @@ template <class FMHAKernel, bool isVarLen = false> struct ExampleRunner {
     block_ref_O.reset(static_cast<std::size_t>(batch) * num_heads_q * seq_len_qo * head_size_vo);
     // Zero-initialize output buffer for the kernel result
     // block_ref_O is fully written in verify() before being read, so no initialization needed
-    compat::memset(block_O.get(), 0, block_O.size() * sizeof(ElementO));
+    compat::memset(block_O.get(), 0, block_O.size() * sizeof_bits_v<ElementO> / 8);
     if (options.use_paged_kv) {
       paged_kv_cache.page_size = options.page_size;
       std::vector<int> num_pages_per_seq{0};
@@ -780,23 +780,60 @@ template <class FMHAKernel, bool isVarLen = false> struct ExampleRunner {
         run(params);
       }
       compat::wait();
-    // when seq_len_qo is not equal to seq_len_kv we use bottom up approach for the masking.
-      // Following changes will adjust the effective_seq_len_kv when masking applied for such cases
-      auto offset = cute::min(options.seq_len_qo, options.seq_len_kv);
-      auto discard_seq_coord = options.seq_len_qo - offset;
-      auto full_tile_offset = options.seq_len_kv - offset;
-      // offset + 1 is going to be ceil_div
-      auto effective_seq_len_kv = options.is_causal ? full_tile_offset + ((offset + 1) / 2.0): options.seq_len_kv;
-      auto effective_seq_len_qo = options.is_causal ? options.seq_len_qo - discard_seq_coord : options.seq_len_qo;
       double cute_time = timer.seconds() / options.iterations;
-      double flops_qk = 2.0 * options.batch * options.num_heads_q * effective_seq_len_qo * effective_seq_len_kv * options.head_size_qk;
-      double flops_pv = 2.0 *  options.batch * options.num_heads_q * effective_seq_len_qo * options.head_size_vo * effective_seq_len_kv;
+      double batched_effective_seq_len_qo_x_kv = 0.0;  // flops_qk and flops_pv
+      double batched_effective_seq_len_qo = 0.0;       // gbps_q and gbps_o
+      double batched_effective_seq_len_kv = 0.0;       // gbps_kv
+      double batched_seq_len_kv_cache = 0.0;           // gbps_kv_cache
+      if constexpr (isVarLen) {
+        // For varlen, we need to iterate over each batch and compute per-batch flops
+        for (int b = 0; b < options.batch; ++b) {
+          int seq_len_qo = cumulative_seqlen_q[b + 1] - cumulative_seqlen_q[b];
+          int seq_len_kv = cumulative_seqlen_kv[b + 1] - cumulative_seqlen_kv[b];
+          int seq_len_kv_cache = 0;
+          if (options.seq_len_kv_cache > 0) {
+            seq_len_kv_cache = cumulative_seqlen_kv_cache[b + 1] - cumulative_seqlen_kv_cache[b];
+          }
+          auto offset = cute::min(seq_len_qo, seq_len_kv);
+          auto discard_seq_coord = seq_len_qo - offset;
+          auto full_tile_offset = seq_len_kv - offset;
+          // offset + 1 is going to be ceil_div
+          auto per_batch_effective_seq_len_kv = options.is_causal ? full_tile_offset + ((offset + 1) / 2.0) : static_cast<double>(seq_len_kv);
+          auto per_batch_effective_seq_len_qo = options.is_causal ? seq_len_qo - discard_seq_coord : seq_len_qo;
+          double per_batch_qo_x_kv_cache = static_cast<double>(seq_len_qo) * seq_len_kv_cache;  // Full attention to cache
+          double per_batch_qo_x_kv_new = per_batch_effective_seq_len_qo * per_batch_effective_seq_len_kv;  // Causal-adjusted for new KV
+
+          batched_effective_seq_len_qo_x_kv += per_batch_qo_x_kv_cache + per_batch_qo_x_kv_new;
+          batched_effective_seq_len_qo += per_batch_effective_seq_len_qo;
+          batched_effective_seq_len_kv += per_batch_effective_seq_len_kv;
+          batched_seq_len_kv_cache += seq_len_kv_cache;
+        }
+      } else {
+        // Non-varlen
+        int seq_len_kv_cache = options.seq_len_kv_cache;
+        auto offset = cute::min(options.seq_len_qo, options.seq_len_kv);
+        auto discard_seq_coord = options.seq_len_qo - offset;
+        auto full_tile_offset = options.seq_len_kv - offset;
+        auto effective_seq_len_kv = options.is_causal ? full_tile_offset + ((offset + 1) / 2.0) : static_cast<double>(options.seq_len_kv);
+        auto effective_seq_len_qo = options.is_causal ? options.seq_len_qo - discard_seq_coord : options.seq_len_qo;
+        double qo_x_kv_cache = static_cast<double>(options.seq_len_qo) * seq_len_kv_cache;  // Full attention to cache
+        double qo_x_kv_new = effective_seq_len_qo * effective_seq_len_kv;  // Causal-adjusted for new KV
+
+        batched_effective_seq_len_qo_x_kv = options.batch * (qo_x_kv_cache + qo_x_kv_new);
+        batched_effective_seq_len_qo = options.batch * effective_seq_len_qo;
+        batched_effective_seq_len_kv = options.batch * effective_seq_len_kv;
+        batched_seq_len_kv_cache = options.batch * seq_len_kv_cache;
+      }
+
+      double flops_qk = 2.0 * options.num_heads_q * batched_effective_seq_len_qo_x_kv * options.head_size_qk;
+      double flops_pv = 2.0 * options.num_heads_q * batched_effective_seq_len_qo_x_kv * options.head_size_vo;
       double tflops = ((flops_qk + flops_pv) * 1e-12) / cute_time;
-      double gbps_qk =  options.batch * (sizeof(ElementQ) * options.num_heads_q * effective_seq_len_qo * options.head_size_qk +
-                                         sizeof(ElementK) * options.num_heads_kv * effective_seq_len_kv * options.head_size_qk);
-      double gbps_pv = sizeof(ElementV) * options.batch * options.num_heads_kv * effective_seq_len_kv * options.head_size_vo +
-                     sizeof(ElementO) * options.batch * options.num_heads_q * effective_seq_len_qo * options.head_size_vo;
-      double gbps = ((gbps_qk + gbps_pv)  * 1e-9) / (cute_time);
+      
+      double gbps_qk = options.num_heads_q * batched_effective_seq_len_qo * options.head_size_qk * sizeof_bits_v<ElementQ> / 8 +
+                       options.num_heads_kv * batched_effective_seq_len_kv * options.head_size_qk * sizeof_bits_v<ElementK> / 8;
+      double gbps_pv = options.num_heads_kv * batched_effective_seq_len_kv * options.head_size_vo * sizeof_bits_v<ElementV> / 8 +
+                       options.num_heads_q * batched_effective_seq_len_qo * options.head_size_vo * sizeof_bits_v<ElementO> / 8;
+      double gbps = ((gbps_qk + gbps_pv) * 1e-9) / cute_time;
       std::cout << "Batch: " << options.batch << "\tNumHeads_q: " << options.num_heads_q  << "\tNumHeads_kv: " << options.num_heads_kv  << "\tSeq Length QO: " << options.seq_len_qo
                 << "\tSeq Length KV: " << options.seq_len_kv << "\tHead Size QK: " << options.head_size_qk << "\tHead Size VO: " << options.head_size_vo
                 << "\tCausal Mask: " << (options.is_causal ? "true" : "false") << "\tVariable Sequence Length: " << (options.varlen ? "true" : "false")

--- a/include/cute/atom/copy_traits_xe_2d.hpp
+++ b/include/cute/atom/copy_traits_xe_2d.hpp
@@ -1414,7 +1414,7 @@ make_block_2d_copy_C_subtiled(TiledMMA             const& mma,         // TiledM
                               SubtileSGLayout      const& ssg_layout,  // Subtile subgroup layout: SG_K -> (m_subtile,n_subtile)
                               Stride<Strides...>   const& gstride)     // Global memory strides
 {
-  using MMAType = typename TiledMMA::ValTypeA;
+  using MMAType = typename TiledMMA::ValTypeC;
   auto op = block_2d_selector<ValType, MMAType>(stv_layout, gstride);
   return make_block_2d_copy_CD_subtiled<ValType>(op, mma, atuple_coshape(stv_layout), ssg_layout, gstride);
 }
@@ -1430,7 +1430,7 @@ make_block_2d_copy_D_subtiled(TiledMMA             const& mma,         // TiledM
                               SubtileSGLayout      const& ssg_layout,  // Subtile subgroup layout: SG_K -> (m_subtile,n_subtile)
                               Stride<Strides...>   const& gstride)     // Global memory strides
 {
-  using MMAType = typename TiledMMA::ValTypeA;
+  using MMAType = typename TiledMMA::ValTypeD;
   auto op = block_2d_selector<ValType, MMAType, true>(stv_layout, gstride);
   return make_block_2d_copy_CD_subtiled<ValType>(op, mma, atuple_coshape(stv_layout), ssg_layout, gstride);
 }


### PR DESCRIPTION
## Description
1. Unified mainloop body: Consolidated CachedKV and newly generated KV into a single mainloop body with cleaner code structure and eliminate branches
2. VarLen calculations used user-provided seq_len_kv and seq_len_qo, leading to a performance overestimation. Introduce a precise, per-batch calculation using the actual generated sequence lengths, ensuring accurate performance data. 
3. Add cachedKV performance metric calculation.
4. Relocated Q and K prefetch operations outside the blk_k0 == 0 condition to enhance prefetch coverage for splitK decode
5. Enhanced V prefetch partitioning to correctly handle the VTiles dimension.
6. Restructured softmax rescale computation to reduce register pressure.
7. Fixed the ValType bug in make_block_2d_copy_C/D_subtiled.
8. Correct bit-width calculation for sub-8-bit data types (e.g., FP4).

## Type
- [ * ] Bug  - [ ] Feature  - [ * ] Performance  - [ * ] Refactor

