### PR TITLE
Fix fa decode memory bandwidth computation in 06_bmg_flash_attention …

### DIFF
--- a/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
+++ b/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
@@ -837,9 +837,10 @@ template <class FMHAKernel, bool isVarLen = false> struct ExampleRunner {
       double flops_pv = 2.0 * options.num_heads_q * batched_effective_seq_len_qo_x_kv * options.head_size_vo;
       double tflops = ((flops_qk + flops_pv) * 1e-12) / cute_time;
       
+      double batched_seq_len_kv_total = batched_effective_seq_len_kv + batched_seq_len_kv_cache;
       double gbps_qk = options.num_heads_q * batched_effective_seq_len_qo * options.head_size_qk * sizeof_bits_v<ElementQ> / 8 +
-                       options.num_heads_kv * batched_effective_seq_len_kv * options.head_size_qk * sizeof_bits_v<ElementK> / 8;
-      double gbps_pv = options.num_heads_kv * batched_effective_seq_len_kv * options.head_size_vo * sizeof_bits_v<ElementV> / 8 +
+                       options.num_heads_kv * batched_seq_len_kv_total * options.head_size_qk * sizeof_bits_v<ElementK> / 8;
+      double gbps_pv = options.num_heads_kv * batched_seq_len_kv_total * options.head_size_vo * sizeof_bits_v<ElementV> / 8 +
                        options.num_heads_q * batched_effective_seq_len_qo * options.head_size_vo * sizeof_bits_v<ElementO> / 8;
       double gbps = ((gbps_qk + gbps_pv) * 1e-9) / cute_time;
       std::cout << "Batch: " << options.batch << "\tNumHeads_q: " << options.num_heads_q  << "\tNumHeads_kv: " << options.num_heads_kv  << "\tSeq Length QO: " << options.seq_len_qo


### PR DESCRIPTION
## Description
The bandwidth metric reported by the FMHA forward runner ignored the KV-cache portion when computing K/V byte traffic. For decode/prefix-cache workloads where `seq_len_kv_cache` > 0, this caused the printed GB/s to under-count actual DRAM traffic by a factor of up to (kv + kv_cache) / kv.

For example:
```
$ ./06_xe_fmha_fwd_decode_bfloat16_t_hdim128 --iterations=100 --batch=16 --verify=0 --num_heads_q=80 --num_heads_kv=8 --head_size_qk=128 --head_size_vo=128 --seq_len_qo=1 --seq_len_kv=1 --seq_len_kv_cache=10240
Disposition is skipped.
Batch: 16       NumHeads_q: 80  NumHeads_kv: 8  Seq Length QO: 1        Seq Length KV: 1        Head Size QK: 128       Head Size VO: 128       Causal Mask: false      Variable Sequence Length: false  Scheduler: Individual
Performance:   0.253  GB/s,    1.621  TFlop/s,   4.1408  ms
```

The memory bandwidth only has 0.253  GB/s

After this patch, the memory bandwidth can be computed better.
```
$ ./06_xe_fmha_fwd_decode_bfloat16_t_hdim128 --iterations=100 --batch=16 --verify=0 --num_heads_q=80 --num_heads_kv=8 --head_size_qk=128 --head_size_vo=128 --seq_len_qo=1 --seq_len_kv=1 --seq_len_kv_cache=10240
Disposition is skipped.
Batch: 16       NumHeads_q: 80  NumHeads_kv: 8  Seq Length QO: 1        Seq Length KV: 1        Head Size QK: 128       Head Size VO: 128       Causal Mask: false      Variable Sequence Length: false  Scheduler: Individual
Performance:   162.213  GB/s,    1.620  TFlop/s,   4.1436  ms
```

## Type
- [*] Bug  - [ ] Feature  - [ ] Performance  - [ ] Refactor

## Testing
- [ ] Tests pass  - [ ] Xe12  - [ ] Xe20

## Performance
| Metric | Before | After |
|--------|--------|-------|
|        |        |       |

## References
Fixes #

## Checklist
- [ ] Copyright  - [ ] Co-pilot Review  - [ ] Deprecated APIs not used
