### PR TITLE
add Handler-less and Event-less support in launch APIs

### DIFF
--- a/include/cute/util/compat/launch.hpp
+++ b/include/cute/util/compat/launch.hpp
@@ -126,8 +126,8 @@ namespace compat::experimental {
 
 namespace detail {
 
-template <auto F, class N, typename LaunchPolicy, typename... Args>
-sycl::event launch(LaunchPolicy launch_policy, sycl::queue q, Args... args) {
+template <auto F, class N = sycl::detail::auto_name, bool EventNeeded = true, typename LaunchPolicy, typename... Args>
+auto launch(LaunchPolicy launch_policy, sycl::queue q, Args... args) {
   static_assert(compat::args_compatible<LaunchPolicy, F, Args...>,
                 "Mismatch between device function signature and supplied "
                 "arguments. Have you correctly handled local memory/char*?");
@@ -135,32 +135,50 @@ sycl::event launch(LaunchPolicy launch_policy, sycl::queue q, Args... args) {
   sycl_exp::launch_config config(launch_policy.get_range(),
                                  launch_policy.get_launch_properties());
 
-  return sycl_exp::submit_with_event(q, [&](sycl::handler &cgh) {
-    auto KernelFunctor = build_kernel_functor<F>(cgh, launch_policy, args...);
-    if constexpr (compat::detail::is_range_v<
-                      typename LaunchPolicy::RangeT>) {
-      sycl_exp::parallel_for<N>(cgh, config, KernelFunctor);
+  if constexpr (EventNeeded) {
+    return sycl_exp::submit_with_event(q, [&](sycl::handler &cgh) {
+      auto KernelFunctor = build_kernel_functor<F>(cgh, launch_policy, args...);
+      if constexpr (compat::detail::is_range_v<typename LaunchPolicy::RangeT>) {
+        sycl_exp::parallel_for<N>(cgh, config, KernelFunctor);
+      } else {
+        static_assert(compat::detail::is_nd_range_v<typename LaunchPolicy::RangeT>);
+        sycl_exp::nd_launch<N>(cgh, config, KernelFunctor);
+      }
+    });
+  } else if constexpr (LaunchPolicy::HasLocalMem && launch_policy.get_local_mem_size() != 0) {
+    sycl_exp::submit(q, [&](sycl::handler &cgh) {
+      auto KernelFunctor = build_kernel_functor<F>(cgh, launch_policy, args...);
+      if constexpr (compat::detail::is_range_v<typename LaunchPolicy::RangeT>) {
+        sycl_exp::parallel_for<N>(cgh, config, KernelFunctor);
+      } else {
+        static_assert(compat::detail::is_nd_range_v<typename LaunchPolicy::RangeT>);
+        sycl_exp::nd_launch<N>(cgh, config, KernelFunctor);
+      }
+    });
+  } else {
+    auto KernelFunctor = build_kernel_functor<F>(launch_policy, args...);
+    if constexpr (compat::detail::is_range_v<typename LaunchPolicy::RangeT>) {
+      sycl_exp::parallel_for(q, config, KernelFunctor);
     } else {
-      static_assert(
-          compat::detail::is_nd_range_v<typename LaunchPolicy::RangeT>);
-      sycl_exp::nd_launch<N>(cgh, config, KernelFunctor);
+      static_assert(compat::detail::is_nd_range_v<typename LaunchPolicy::RangeT>);
+      sycl_exp::nd_launch(q, config, KernelFunctor);
     }
-  });
+  }
 }
 
 }
 
 
-template <auto F, class N=sycl::detail::auto_name, typename LaunchPolicy, typename... Args>
-sycl::event launch(LaunchPolicy launch_policy, sycl::queue q, Args... args) {
+template <auto F, class N = sycl::detail::auto_name, bool EventNeeded = true, typename LaunchPolicy, typename... Args>
+auto launch(LaunchPolicy launch_policy, sycl::queue q, Args... args) {
   static_assert(detail::is_launch_policy_v<LaunchPolicy>);
-  return detail::launch<F, N>(launch_policy, q, args...);
+  return detail::launch<F, N, EventNeeded>(launch_policy, q, args...);
 }
 
-template <auto F, class N=sycl::detail::auto_name, typename LaunchPolicy, typename... Args>
-sycl::event launch(LaunchPolicy launch_policy, Args... args) {
+template <auto F, class N = sycl::detail::auto_name, bool EventNeeded = true, typename LaunchPolicy, typename... Args>
+auto launch(LaunchPolicy launch_policy, Args... args) {
   static_assert(detail::is_launch_policy_v<LaunchPolicy>);
-  return launch<F, N>(launch_policy, get_default_queue(), args...);
+  return launch<F, N, EventNeeded>(launch_policy, get_default_queue(), args...);
 }
 
 } // namespace compat::experimental

--- a/include/cute/util/compat/launch_policy.hpp
+++ b/include/cute/util/compat/launch_policy.hpp
@@ -249,6 +249,14 @@ struct KernelFunctor {
 //====================================================================
 // This helper function avoids 2 nested `if constexpr` in detail::launch
 template <auto F, typename LaunchPolicy, typename... Args>
+auto build_kernel_functor(LaunchPolicy launch_policy, Args... args) {
+  return KernelFunctor<F, typename LaunchPolicy::RangeT,
+                       typename LaunchPolicy::KPropsT,
+                       LaunchPolicy::HasLocalMem, Args...>(
+      launch_policy.get_kernel_properties(), args...);
+}
+
+template <auto F, typename LaunchPolicy, typename... Args>
 auto build_kernel_functor(sycl::handler &cgh, LaunchPolicy launch_policy,
                           Args... args)
     -> KernelFunctor<F, typename LaunchPolicy::RangeT,
@@ -262,10 +270,7 @@ auto build_kernel_functor(sycl::handler &cgh, LaunchPolicy launch_policy,
                          LaunchPolicy::HasLocalMem, Args...>(
         launch_policy.get_kernel_properties(), local_memory, args...);
   } else {
-    return KernelFunctor<F, typename LaunchPolicy::RangeT,
-                         typename LaunchPolicy::KPropsT,
-                         LaunchPolicy::HasLocalMem, Args...>(
-        launch_policy.get_kernel_properties(), args...);
+    return build_kernel_functor<F, LaunchPolicy, Args...>(launch_policy, args...);
   }
 }
 


### PR DESCRIPTION
according to "SYCL API Guide" described as following:
    __Call to Action: Use appropriate APIs to get performance.
    Try to avoid sycl::handler where possible
    If you do not need sycl::event to be returned use APIs that return void__

add Handler-less and Event-less support in launch APIs, refer to https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/ext/oneapi/experimental/enqueue_functions.hpp#L227
