### PR TITLE
Update googlebenchmark to v1.9.5

### DIFF
--- a/cmake/googlebenchmark.cmake
+++ b/cmake/googlebenchmark.cmake
@@ -39,7 +39,7 @@ set(GBENCH_REPOSITORY "https://github.com/google/benchmark.git" CACHE STRING "Go
 FetchContent_Declare(
   googlebenchmark
   GIT_REPOSITORY ${GBENCH_REPOSITORY}
-  GIT_TAG        v1.9.0
+  GIT_TAG        v1.9.5
   EXCLUDE_FROM_ALL
   )
 


### PR DESCRIPTION
clang version 22 has changed handling of `__COUNTER__` macro which affected googlebenchmark build. The latter was addressed in `v1.9.5`.

The clang 22 is a base of the upcoming open source DPC++ compler `v7.0.0` which should be matched by oneAPI 2026.0.0.

```
/opt/sycl-tla/_build/_deps/googlebenchmark-src/include/benchmark/benchmark.h:1487:30: error: '__COUNTER__' is a C2y extension
      [-Werror,-Wc2y-extensions]
 1487 | #if defined(__COUNTER__) && (__COUNTER__ + 1 == __COUNTER__ + 0)
```

See: https://github.com/google/benchmark/issues/2057
See: https://releases.llvm.org/22.1.0/tools/clang/docs/ReleaseNotes.html#c2y-feature-support

CC: @Antonyvance