### PR TITLE
use event-less launch when profiling is disabled in GemmUniversalAdapter

### DIFF
--- a/benchmarks/flash_attention/benchmark_runner.hpp
+++ b/benchmarks/flash_attention/benchmark_runner.hpp
@@ -669,9 +669,12 @@ template <class FMHAConfiguration> struct BenchmarkRunnerFMHA {
 #endif
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<FMHAKernel>, FMHAKernel>(policy, params);
-
     EventManager::getInstance().addEvent(event);
+#else
+    compat::experimental::launch<cutlass::device_kernel<FMHAKernel>, FMHAKernel, false>(policy, params);
+#endif
   }
 
   void run(::benchmark::State& state, const FMHAOptions &options, const cutlass::KernelHardwareInfo &hw_info) {

--- a/benchmarks/flash_attention/legacy/flash_attention_decode/benchmark_runner.hpp
+++ b/benchmarks/flash_attention/legacy/flash_attention_decode/benchmark_runner.hpp
@@ -619,10 +619,18 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
 
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<FMHADecodeKernel>, FMHADecodeKernel>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<FMHADecodeKernel::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+    #else
+    launch<cutlass::device_kernel<FMHADecodeKernel>, FMHADecodeKernel, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<FMHADecodeKernel::DispatchPolicy::SubgroupSize>}},
+        params);
+    #endif
 #else
     compat::experimental::launch_properties launch_props{
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size)
@@ -631,10 +639,13 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
       sycl::ext::oneapi::experimental::sub_group_size<FMHADecodeKernel::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<FMHADecodeKernel>, FMHADecodeKernel>(policy, params);
-#endif
-
     EventManager::getInstance().addEvent(event);
+    #else
+        compat::experimental::launch<cutlass::device_kernel<FMHADecodeKernel>, FMHADecodeKernel, false>(policy, params);
+    #endif
+#endif
   }
 
   void run(::benchmark::State& state, const FMHADecodeOptions &options, const cutlass::KernelHardwareInfo &hw_info) {

--- a/benchmarks/flash_attention/legacy/flash_attention_prefill/benchmark_runner.hpp
+++ b/benchmarks/flash_attention/legacy/flash_attention_prefill/benchmark_runner.hpp
@@ -479,10 +479,18 @@ template <class FMHAPrefillConfiguration> struct BenchmarkRunnerFMHA {
 
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<GemmKernel>>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<GemmKernel::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+    #else
+    launch<cutlass::device_kernel<GemmKernel>, sycl::detail::auto_name, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<GemmKernel::DispatchPolicy::SubgroupSize>}},
+        params);
+    #endif
 #else
     compat::experimental::launch_properties launch_props{
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size)
@@ -491,10 +499,13 @@ template <class FMHAPrefillConfiguration> struct BenchmarkRunnerFMHA {
       sycl::ext::oneapi::experimental::sub_group_size<GemmKernel::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<GemmKernel>, GemmKernel>(policy, params);
-#endif
-
     EventManager::getInstance().addEvent(event);
+    #else
+        compat::experimental::launch<cutlass::device_kernel<GemmKernel>, GemmKernel, false>(policy, params);
+    #endif
+#endif
   }
 
   void run(::benchmark::State& state, const FMHAOptions &options, const cutlass::KernelHardwareInfo &hw_info) {

--- a/benchmarks/flash_attention/legacy/flash_attention_prefill_cachedKV/benchmark_runner.hpp
+++ b/benchmarks/flash_attention/legacy/flash_attention_prefill_cachedKV/benchmark_runner.hpp
@@ -572,10 +572,18 @@ template <class FMHAPrefillConfiguration> struct BenchmarkRunnerFMHA {
 
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<GemmKernel>>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<GemmKernel::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+    #else
+    launch<cutlass::device_kernel<GemmKernel>, sycl::detail::auto_name, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<GemmKernel::DispatchPolicy::SubgroupSize>}},
+        params);
+    #endif
 #else
     compat::experimental::launch_properties launch_props{
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size)
@@ -584,10 +592,13 @@ template <class FMHAPrefillConfiguration> struct BenchmarkRunnerFMHA {
       sycl::ext::oneapi::experimental::sub_group_size<GemmKernel::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<GemmKernel>, GemmKernel>(policy, params);
-#endif
-
     EventManager::getInstance().addEvent(event);
+    #else
+        compat::experimental::launch<cutlass::device_kernel<GemmKernel>, GemmKernel, false>(policy, params);
+    #endif
+#endif
   }
 
   void run(::benchmark::State& state, const FMHAOptions &options, const cutlass::KernelHardwareInfo &hw_info) {

--- a/examples/06_bmg_flash_attention/legacy/bmg_flash_attn_decode_runner.hpp
+++ b/examples/06_bmg_flash_attention/legacy/bmg_flash_attn_decode_runner.hpp
@@ -634,10 +634,18 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
 
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<FMHAKernel>>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<FMHAKernel::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+    #else
+    launch<cutlass::device_kernel<FMHAKernel>, sycl::detail::auto_name, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<FMHAKernel::DispatchPolicy::SubgroupSize>}},
+        params);
+    #endif
 #else
     compat::experimental::launch_properties launch_props {
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size),
@@ -646,10 +654,13 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
       sycl::ext::oneapi::experimental::sub_group_size<FMHAKernel::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<FMHAKernel>, FMHAKernel>(policy, params);
-#endif
-
     EventManager::getInstance().addEvent(event);
+    #else
+        compat::experimental::launch<cutlass::device_kernel<FMHAKernel>, FMHAKernel, false>(policy, params);
+    #endif
+#endif
   }
 
   cutlass::Status run(const Options &options, const cutlass::KernelHardwareInfo &hw_info) {

--- a/examples/06_bmg_flash_attention/legacy/bmg_flash_attn_prefill_cachedKV_runner.hpp
+++ b/examples/06_bmg_flash_attention/legacy/bmg_flash_attn_prefill_cachedKV_runner.hpp
@@ -617,10 +617,18 @@ template <class FMHAPrefillCachedKernel, bool isVarLen> struct ExampleRunner {
 // Launch parameters depend on whether SYCL compiler supports work-group scratch memory extension
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<FMHAPrefillCachedKernel>>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<FMHAPrefillCachedKernel::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+    #else
+    launch<cutlass::device_kernel<FMHAPrefillCachedKernel>, sycl::detail::auto_name, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<FMHAPrefillCachedKernel::DispatchPolicy::SubgroupSize>}},
+        params);
+    #endif
 #else
     compat::experimental::launch_properties launch_props {
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size),
@@ -629,10 +637,13 @@ template <class FMHAPrefillCachedKernel, bool isVarLen> struct ExampleRunner {
       sycl::ext::oneapi::experimental::sub_group_size<FMHAPrefillCachedKernel::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<FMHAPrefillCachedKernel>, FMHAPrefillCachedKernel>(policy, params);
-#endif
-
     EventManager::getInstance().addEvent(event);
+    #else
+        compat::experimental::launch<cutlass::device_kernel<FMHAPrefillCachedKernel>, FMHAPrefillCachedKernel, false>(policy, params);
+    #endif
+#endif
   }
 
   cutlass::Status run(const Options &options, const cutlass::KernelHardwareInfo &hw_info) {

--- a/examples/06_bmg_flash_attention/legacy/bmg_flash_attn_prefill_runner.hpp
+++ b/examples/06_bmg_flash_attention/legacy/bmg_flash_attn_prefill_runner.hpp
@@ -498,10 +498,18 @@ template <class FMHAPrefillKernel, bool isVarLen> struct ExampleRunner {
 // Launch parameters depend on whether SYCL compiler supports work-group scratch memory extension
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<FMHAPrefillKernel>>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<FMHAPrefillKernel::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+    #else
+    launch<cutlass::device_kernel<FMHAPrefillKernel>, sycl::detail::auto_name, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<FMHAPrefillKernel::DispatchPolicy::SubgroupSize>}},
+        params);
+    #endif
 #else
     compat::experimental::launch_properties launch_props {
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size),
@@ -510,10 +518,13 @@ template <class FMHAPrefillKernel, bool isVarLen> struct ExampleRunner {
       sycl::ext::oneapi::experimental::sub_group_size<FMHAPrefillKernel::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<FMHAPrefillKernel>, FMHAPrefillKernel>(policy, params);
-#endif
-
     EventManager::getInstance().addEvent(event);
+    #else
+        compat::experimental::launch<cutlass::device_kernel<FMHAPrefillKernel>, FMHAPrefillKernel, false>(policy, params);
+    #endif
+#endif
   }
 
   cutlass::Status run(const Options &options, const cutlass::KernelHardwareInfo &hw_info) {

--- a/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
+++ b/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
@@ -717,9 +717,12 @@ template <class FMHAKernel, bool isVarLen = false> struct ExampleRunner {
       intelex::grf_size<256>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<FMHAKernel>, FMHAKernel>(policy, params);
-
     EventManager::getInstance().addEvent(event);
+#else
+    compat::experimental::launch<cutlass::device_kernel<FMHAKernel>, FMHAKernel, false>(policy, params);
+#endif
   }
 
   cutlass::Status run(const Options &options, const cutlass::KernelHardwareInfo &hw_info) {

--- a/examples/07_bmg_dual_gemm/07_bmg_dual_gemm.cpp
+++ b/examples/07_bmg_dual_gemm/07_bmg_dual_gemm.cpp
@@ -332,10 +332,18 @@ struct ExampleRunner {
 
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<GemmKernel>>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<GemmKernel::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+#else
+    launch<cutlass::device_kernel<GemmKernel>, sycl::detail::auto_name, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<GemmKernel::DispatchPolicy::SubgroupSize>}},
+        params);
+#endif
 #else
     compat::experimental::launch_properties launch_props{
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size)
@@ -344,10 +352,13 @@ struct ExampleRunner {
       sycl::ext::oneapi::experimental::sub_group_size<GemmKernel::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<GemmKernel>, GemmKernel>(policy, params);
-#endif
-
     EventManager::getInstance().addEvent(event);
+#else
+    compat::experimental::launch<cutlass::device_kernel<GemmKernel>, GemmKernel, false>(policy, params);
+#endif
+#endif
     return cutlass::Status::kSuccess;
   }
 

--- a/examples/cute/tutorial/bgemm_bmg_legacy.cpp
+++ b/examples/cute/tutorial/bgemm_bmg_legacy.cpp
@@ -331,6 +331,7 @@ gemm_nt(int m, int n, int k,
   compat::experimental::launch_policy policy{
     dimGrid, dimBlock, launch_props, kernel_props
   };
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   auto event = compat::experimental::launch<
     gemm_device<decltype(prob_shape), decltype(cta_tiler),
                 TA, decltype(dA), decltype(copyA),
@@ -345,8 +346,23 @@ gemm_nt(int m, int n, int k,
                     B, dB, copyB,
                     C, dC, copyC, mmaC,
                     alpha, beta);
-
   EventManager::getInstance().addEvent(event);
+#else
+  compat::experimental::launch<
+    gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                TA, decltype(dA), decltype(copyA),
+                TB, decltype(dB), decltype(copyB),
+                TC, decltype(dC), decltype(copyC), decltype(mmaC),
+                Alpha, Beta>, GemmDeviceName<decltype(prob_shape), decltype(cta_tiler),
+                TA, decltype(dA), decltype(copyA),
+                TB, decltype(dB), decltype(copyB),
+                TC, decltype(dC), decltype(copyC), decltype(mmaC),
+                Alpha, Beta>, false>(policy, prob_shape, cta_tiler, bP,
+                    A, dA, copyA,
+                    B, dB, copyB,
+                    C, dC, copyC, mmaC,
+                    alpha, beta);
+#endif
 }
 
 // Setup params for a NT GEMM
@@ -412,6 +428,7 @@ gemm_tn(int m, int n, int k,
   compat::experimental::launch_policy policy{
     dimGrid, dimBlock, launch_props, kernel_props
   };
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   auto event = compat::experimental::launch<
     gemm_device<decltype(prob_shape), decltype(cta_tiler),
                 TA, decltype(dA), decltype(copyA),
@@ -427,6 +444,22 @@ gemm_tn(int m, int n, int k,
                     C, dC, copyC, mmaC,
                     alpha, beta);
   EventManager::getInstance().addEvent(event);
+#else
+  compat::experimental::launch<
+    gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                TA, decltype(dA), decltype(copyA),
+                TB, decltype(dB), decltype(copyB),
+                TC, decltype(dC), decltype(copyC), decltype(mmaC),
+                Alpha, Beta>, GemmDeviceName<decltype(prob_shape), decltype(cta_tiler),
+                TA, decltype(dA), decltype(copyA),
+                TB, decltype(dB), decltype(copyB),
+                TC, decltype(dC), decltype(copyC), decltype(mmaC),
+                Alpha, Beta>, false>(policy, prob_shape, cta_tiler, bP,
+                    A, dA, copyA,
+                    B, dB, copyB,
+                    C, dC, copyC, mmaC,
+                    alpha, beta);
+#endif
 }
 
 template <class TA, class TB, class TC,
@@ -492,6 +525,7 @@ gemm_tt(int m, int n, int k,
   compat::experimental::launch_policy policy{
     dimGrid, dimBlock, launch_props, kernel_props
   };
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   auto event = compat::experimental::launch<
     gemm_device<decltype(prob_shape), decltype(cta_tiler),
                 TA, decltype(dA), decltype(copyA),
@@ -506,8 +540,23 @@ gemm_tt(int m, int n, int k,
                     B, dB, copyB,
                     C, dC, copyC, mmaC,
                     alpha, beta);
-
   EventManager::getInstance().addEvent(event);
+#else
+  compat::experimental::launch<
+    gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                TA, decltype(dA), decltype(copyA),
+                TB, decltype(dB), decltype(copyB),
+                TC, decltype(dC), decltype(copyC), decltype(mmaC),
+                Alpha, Beta>, GemmDeviceName<decltype(prob_shape), decltype(cta_tiler),
+                TA, decltype(dA), decltype(copyA),
+                TB, decltype(dB), decltype(copyB),
+                TC, decltype(dC), decltype(copyC), decltype(mmaC),
+                Alpha, Beta>, false>(policy, prob_shape, cta_tiler, bP,
+                    A, dA, copyA,
+                    B, dB, copyB,
+                    C, dC, copyC, mmaC,
+                    alpha, beta);
+#endif
 }
 
 template <class TA, class TB, class TC,

--- a/examples/cute/tutorial/sgemm_1_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_1_sycl.cpp
@@ -300,7 +300,9 @@ gemm_nt(int m, int n, int k,
                                 B, dB, sB, tB,
                                 C, dC, sC, tC,
                                 alpha, beta);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   EventManager::getInstance().addEvent(event);
+#endif
 }
 
 // Setup params for a TN GEMM
@@ -361,7 +363,9 @@ gemm_tn(int m, int n, int k,
                                 B, dB, sB, tB,
                                 C, dC, sC, tC,
                                 alpha, beta);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   EventManager::getInstance().addEvent(event);
+#endif
 }
 
 template <class TA, class TB, class TC,

--- a/examples/cute/tutorial/sgemm_2_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_2_sycl.cpp
@@ -324,7 +324,9 @@ gemm_nt(int m, int n, int k,
                     B, dB, sB, copyB,
                     C, dC, sC, mmaC,
                     alpha, beta);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   EventManager::getInstance().addEvent(event);
+#endif
 }
 
 // Setup params for a TN GEMM
@@ -412,7 +414,9 @@ gemm_tn(int m, int n, int k,
                     B, dB, sB, copyB,
                     C, dC, sC, mmaC,
                     alpha, beta);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   EventManager::getInstance().addEvent(event);
+#endif
 }
 
 template <class TA, class TB, class TC,

--- a/examples/cute/tutorial/sgemm_sm70_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_sm70_sycl.cpp
@@ -317,7 +317,9 @@ gemm_nt(int m, int n, int k,
                     B, dB, sB, copyB,
                     C, dC, sC, mmaC,
                     alpha, beta);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   EventManager::getInstance().addEvent(event);
+#endif
 }
 
 // Setup params for a TN GEMM
@@ -393,7 +395,9 @@ gemm_tn(int m, int n, int k,
                     B, dB, sB, copyB,
                     C, dC, sC, mmaC,
                     alpha, beta);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   EventManager::getInstance().addEvent(event);
+#endif
 }
 
 template <class TA, class TB, class TC,

--- a/examples/cute/tutorial/sgemm_sm80_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_sm80_sycl.cpp
@@ -355,7 +355,9 @@ gemm_nt(int m, int n, int k,
                     B, dB, sB, copyB,
                     C, dC, sC, mmaC,
                     alpha, beta);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   EventManager::getInstance().addEvent(event);
+#endif
 }
 
 // Setup params for a NT GEMM
@@ -434,7 +436,9 @@ gemm_tn(int m, int n, int k,
                     B, dB, sB, copyB,
                     C, dC, sC, mmaC,
                     alpha, beta);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
   EventManager::getInstance().addEvent(event);
+#endif
 }
 
 template <class TA, class TB, class TC,

--- a/examples/nv_sycl/35_gemm_softmax/gemm_softmax_adapter.hpp
+++ b/examples/nv_sycl/35_gemm_softmax/gemm_softmax_adapter.hpp
@@ -462,6 +462,7 @@ public:
           sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size)
         };
         compat::experimental::launch_properties launch_props{smem_prop};
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
         auto event = compat::experimental::launch<device_kernel<GemmKernel>, GemmKernel>(compat::experimental::launch_policy{
           sycl_grid,
           sycl_block,
@@ -470,12 +471,23 @@ public:
           , compat::experimental::kernel_properties{sycl_exp::sub_group_size<DispatchPolicy::SubgroupSize>}
 #endif // defined(SYCL_INTEL_TARGET)
         }, params.gemm_params);
+#else
+        compat::experimental::launch<device_kernel<GemmKernel>, GemmKernel, false>(compat::experimental::launch_policy{
+          sycl_grid,
+          sycl_block,
+          launch_props
+#if defined(SYCL_INTEL_TARGET)
+          , compat::experimental::kernel_properties{sycl_exp::sub_group_size<DispatchPolicy::SubgroupSize>}
+#endif // defined(SYCL_INTEL_TARGET)
+        }, params.gemm_params);
+#endif
 
         compat::experimental::launch_properties kernel_launch_props_finalize{
           sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size_finalize)
         };
         const compat::dim3 sycl_grid_finalize(grid_finalize.x, grid_finalize.y, grid_finalize.z);
         const compat::dim3 sycl_block_finalize(block_finalize.x, block_finalize.y, block_finalize.z);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
         auto event_finalize = compat::experimental::launch<device_kernel<SoftmaxFinalizeKernel>, SoftmaxFinalizeKernel>(compat::experimental::launch_policy{
             sycl_grid_finalize,
             sycl_block_finalize,
@@ -483,19 +495,41 @@ public:
           }, params.softmax_params);
         EventManager::getInstance().addEvent(event_finalize);
 #else
+        compat::experimental::launch<device_kernel<SoftmaxFinalizeKernel>, SoftmaxFinalizeKernel, false>(compat::experimental::launch_policy{
+            sycl_grid_finalize,
+            sycl_block_finalize,
+            kernel_launch_props_finalize,
+          }, params.softmax_params);
+#endif
+#else
         using namespace compat::experimental;
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
         auto event = launch<device_kernel<GemmKernel>>(launch_policy{
           sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)}
 #if defined (SYCL_INTEL_TARGET)
           , kernel_properties{sycl_exp::sub_group_size<DispatchPolicy::SubgroupSize>}
 #endif
         }, params.gemm_params);
+#else
+        launch<device_kernel<GemmKernel>, sycl::detail::auto_name, false>(launch_policy{
+          sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)}
+#if defined (SYCL_INTEL_TARGET)
+          , kernel_properties{sycl_exp::sub_group_size<DispatchPolicy::SubgroupSize>}
+#endif
+        }, params.gemm_params);
+#endif
         const auto sycl_block_finalize = compat::dim3(block_finalize.x, block_finalize.y, block_finalize.z);
         const auto sycl_grid_finalize = compat::dim3(grid_finalize.x, grid_finalize.y, grid_finalize.z);
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
         auto event2 = launch<device_kernel<SoftmaxFinalizeKernel>>(launch_policy{
           sycl_grid_finalize, sycl_block_finalize, local_mem_size{static_cast<std::size_t>(smem_size_finalize)}},
           params.softmax_params);
         EventManager::getInstance().addEvent(event2);
+#else
+        launch<device_kernel<SoftmaxFinalizeKernel>, sycl::detail::auto_name, false>(launch_policy{
+          sycl_grid_finalize, sycl_block_finalize, local_mem_size{static_cast<std::size_t>(smem_size_finalize)}},
+          params.softmax_params);
+#endif
 #endif // defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
 #else
         device_kernel<GemmKernel><<<grid, block, smem_size, stream>>>(params.gemm_params);

--- a/include/cute/util/compat/launch.hpp
+++ b/include/cute/util/compat/launch.hpp
@@ -158,10 +158,10 @@ auto launch(LaunchPolicy launch_policy, sycl::queue q, Args... args) {
   } else {
     auto KernelFunctor = build_kernel_functor<F>(launch_policy, args...);
     if constexpr (compat::detail::is_range_v<typename LaunchPolicy::RangeT>) {
-      sycl_exp::parallel_for(q, config, KernelFunctor);
+      sycl_exp::parallel_for<N>(q, config, KernelFunctor);
     } else {
       static_assert(compat::detail::is_nd_range_v<typename LaunchPolicy::RangeT>);
-      sycl_exp::nd_launch(q, config, KernelFunctor);
+      sycl_exp::nd_launch<N>(q, config, KernelFunctor);
     }
   }
 }

--- a/include/cutlass/gemm/device/gemm_universal_adapter.h
+++ b/include/cutlass/gemm/device/gemm_universal_adapter.h
@@ -1,6 +1,6 @@
 /***************************************************************************************************
  * Copyright (c) 2017 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * Copyright (C) 2025 Intel Corporation, All rights reserved.
+ * Copyright (C) 2025 - 2026 Intel Corporation, All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -552,11 +552,18 @@ public:
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
         using namespace compat::experimental;
         if constexpr (cute::is_same_v<DispatchPolicy, MainloopDeviceAgnostic>) {
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
           auto event = launch<device_kernel<GemmKernel>>(launch_policy{
             sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)}
           }, q, params);
           EventManager::getInstance().addEvent(event);
+#else
+          launch<device_kernel<GemmKernel>, sycl::detail::auto_name, false>(launch_policy{
+            sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)}
+          }, q, params);
+#endif
         } else {
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
           auto event = launch<device_kernel<GemmKernel>>(launch_policy{
             sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)}
 #if defined(SYCL_INTEL_TARGET)
@@ -564,6 +571,14 @@ public:
 #endif
           }, q, params);
           EventManager::getInstance().addEvent(event);
+#else
+          launch<device_kernel<GemmKernel>, sycl::detail::auto_name, false>(launch_policy{
+            sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)}
+#if defined(SYCL_INTEL_TARGET)
+            , kernel_properties{sycl_exp::sub_group_size<DispatchPolicy::SubgroupSize>}
+#endif
+          }, q, params);
+#endif
         }
 #else
 #if defined (SYCL_INTEL_TARGET)
@@ -589,8 +604,12 @@ public:
         compat::experimental::launch_policy policy{
           sycl_grid, sycl_block, launch_props, kernel_props
         };
+#if defined(CUTLASS_SYCL_PROFILING_ENABLED)
         auto event = compat::experimental::launch<device_kernel<GemmKernel>, GemmKernel>(policy, q, params);
         EventManager::getInstance().addEvent(event);
+#else
+        compat::experimental::launch<device_kernel<GemmKernel>, GemmKernel, false>(policy, q, params);
+#endif
 #endif // !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
 #else
 #if (CUTLASS_DEBUG_TRACE_LEVEL > 1)

--- a/test/unit/flash_attention/legacy/flash_attention_decode/flash_decode_testbed_3x.hpp
+++ b/test/unit/flash_attention/legacy/flash_attention_decode/flash_decode_testbed_3x.hpp
@@ -724,10 +724,18 @@ struct TestbedImpl {
 
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<FlashDecode>>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<FlashDecode::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+    #else
+    launch<cutlass::device_kernel<FlashDecode>, sycl::detail::auto_name, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<FlashDecode::DispatchPolicy::SubgroupSize>}},
+        params);
+    #endif
 #else
     compat::experimental::launch_properties launch_props {
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size),
@@ -736,9 +744,13 @@ struct TestbedImpl {
       sycl::ext::oneapi::experimental::sub_group_size<FlashDecode::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<FlashDecode>, FlashDecode>(policy, params);
-#endif
     EventManager::getInstance().addEvent(event);
+    #else
+        compat::experimental::launch<cutlass::device_kernel<FlashDecode>, FlashDecode, false>(policy, params);
+    #endif
+#endif
 
     try {
       compat::wait_and_throw();

--- a/test/unit/flash_attention/legacy/flash_attention_prefill/flash_prefill_testbed_3x.hpp
+++ b/test/unit/flash_attention/legacy/flash_attention_prefill/flash_prefill_testbed_3x.hpp
@@ -634,10 +634,18 @@ struct TestbedImpl {
 
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<FlashAttention>>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<FlashAttention::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+    #else
+    launch<cutlass::device_kernel<FlashAttention>, sycl::detail::auto_name, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<FlashAttention::DispatchPolicy::SubgroupSize>}},
+        params);
+    #endif
 #else
     compat::experimental::launch_properties launch_props {
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size),
@@ -646,9 +654,13 @@ struct TestbedImpl {
       sycl::ext::oneapi::experimental::sub_group_size<FlashAttention::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<FlashAttention>, FlashAttention>(policy, params);
-#endif
     EventManager::getInstance().addEvent(event);
+    #else
+        compat::experimental::launch<cutlass::device_kernel<FlashAttention>, FlashAttention, false>(policy, params);
+    #endif
+#endif
 
     try {
       compat::wait_and_throw();

--- a/test/unit/flash_attention/legacy/flash_attention_prefill_cachedkv/flash_prefill_cachedkv_testbed_3x.hpp
+++ b/test/unit/flash_attention/legacy/flash_attention_prefill_cachedkv/flash_prefill_cachedkv_testbed_3x.hpp
@@ -673,10 +673,18 @@ struct TestbedImpl {
 
 #if !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
     using namespace compat::experimental;
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = launch<cutlass::device_kernel<FlashPrefillCachedKV>>(
         launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
                       kernel_properties{sycl_exp::sub_group_size<FlashPrefillCachedKV::DispatchPolicy::SubgroupSize>}},
         params);
+    EventManager::getInstance().addEvent(event);
+    #else
+    launch<cutlass::device_kernel<FlashPrefillCachedKV>, sycl::detail::auto_name, false>(
+        launch_policy{sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)},
+                      kernel_properties{sycl_exp::sub_group_size<FlashPrefillCachedKV::DispatchPolicy::SubgroupSize>}},
+        params);
+    #endif
 #else
     compat::experimental::launch_properties launch_props {
       sycl::ext::oneapi::experimental::work_group_scratch_size(smem_size),
@@ -685,9 +693,13 @@ struct TestbedImpl {
       sycl::ext::oneapi::experimental::sub_group_size<FlashPrefillCachedKV::DispatchPolicy::SubgroupSize>
     };
     compat::experimental::launch_policy policy{sycl_grid, sycl_block, launch_props, kernel_props};
+    #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
     auto event = compat::experimental::launch<cutlass::device_kernel<FlashPrefillCachedKV>, FlashPrefillCachedKV>(policy, params);
-#endif
     EventManager::getInstance().addEvent(event);
+    #else
+        compat::experimental::launch<cutlass::device_kernel<FlashPrefillCachedKV>, FlashPrefillCachedKV, false>(policy, params);
+    #endif
+#endif
 
     try {
       compat::wait_and_throw();


### PR DESCRIPTION
1. use event-less launch when profiling is disabled in `GemmUniversalAdapter` (follow-up work for https://github.com/intel/sycl-tla/pull/794)
