### PR TITLE
Fix int32 overflow in MoE GEMM for large expert counts

### DIFF
--- a/examples/12_xe20_moe_gemm_cute_interface/12_xe20_moe_gemm_cute_interface.cpp
+++ b/examples/12_xe20_moe_gemm_cute_interface/12_xe20_moe_gemm_cute_interface.cpp
@@ -206,12 +206,12 @@ struct VerificationHelper {
     for (int32_t i = 0; i < groups; ++i) {
       auto problem = problem_sizes_host.at(i);
       auto M = get<0>(problem);
-      cutlass::TensorRef ref_A(activations + cumulative_sum * k,
+      cutlass::TensorRef ref_A(activations + int64_t(cumulative_sum) * k,
                                LayoutA::packed({M, k}));
-      cutlass::TensorRef ref_B(weights + i * n * k, LayoutB::packed({k, n}));
-      cutlass::TensorRef ref_C(unused_c_matrix.get() + cumulative_sum * n,
+      cutlass::TensorRef ref_B(weights + int64_t(i) * n * k, LayoutB::packed({k, n}));
+      cutlass::TensorRef ref_C(unused_c_matrix.get() + int64_t(cumulative_sum) * n,
                                LayoutC::packed({M, n}));
-      cutlass::TensorRef ref_D(output_ref.get() + cumulative_sum * n,
+      cutlass::TensorRef ref_D(output_ref.get() + int64_t(cumulative_sum) * n,
                                LayoutD::packed({M, n}));
 
       //
@@ -234,7 +234,7 @@ struct VerificationHelper {
       // Check if output from CUTLASS kernel and reference kernel are equal or
       // not
       passed &= cutlass::reference::device::BlockCompareEqual(
-          output_ref.get() + cumulative_sum * n, outputs + cumulative_sum * n,
+          output_ref.get() + int64_t(cumulative_sum) * n, outputs + int64_t(cumulative_sum) * n,
           M * n);
       if (!passed) {
         break;
@@ -386,9 +386,9 @@ void launcher(int *M_per_expert, int N, int K, const int &num_experts, const boo
   cutlass::DeviceAllocation<bfloat16_t> activations_data;
   cutlass::DeviceAllocation<bfloat16_t> weights_data;
   cutlass::DeviceAllocation<bfloat16_t> output_data;
-  size_t A_size = num_tokens_incl_duplicated * k_moe;
-  size_t B_size = num_experts * n_moe * k_moe;
-  size_t D_size = num_tokens_incl_duplicated * n_moe;
+  size_t A_size = size_t(num_tokens_incl_duplicated) * k_moe;
+  size_t B_size = size_t(num_experts) * n_moe * k_moe;
+  size_t D_size = size_t(num_tokens_incl_duplicated) * n_moe;
   num_rows_per_expert_device.reset(num_experts);
   num_rows_per_expert_device.copy_from_host(M_per_expert);
   activations_data.reset(A_size);

--- a/examples/12_xe20_moe_gemm_cute_interface/12_xe20_moe_gemm_cute_interface.cpp
+++ b/examples/12_xe20_moe_gemm_cute_interface/12_xe20_moe_gemm_cute_interface.cpp
@@ -386,9 +386,9 @@ void launcher(int *M_per_expert, int N, int K, const int &num_experts, const boo
   cutlass::DeviceAllocation<bfloat16_t> activations_data;
   cutlass::DeviceAllocation<bfloat16_t> weights_data;
   cutlass::DeviceAllocation<bfloat16_t> output_data;
-  size_t A_size = size_t(num_tokens_incl_duplicated) * k_moe;
-  size_t B_size = size_t(num_experts) * n_moe * k_moe;
-  size_t D_size = size_t(num_tokens_incl_duplicated) * n_moe;
+  int64_t A_size = int64_t(num_tokens_incl_duplicated) * k_moe;
+  int64_t B_size = int64_t(num_experts) * n_moe * k_moe;
+  int64_t D_size = int64_t(num_tokens_incl_duplicated) * n_moe;
   num_rows_per_expert_device.reset(num_experts);
   num_rows_per_expert_device.copy_from_host(M_per_expert);
   activations_data.reset(A_size);

--- a/examples/12_xe20_moe_gemm_cute_interface/moe_grouped_gemm.hpp
+++ b/examples/12_xe20_moe_gemm_cute_interface/moe_grouped_gemm.hpp
@@ -115,10 +115,10 @@ MoEGEMM(const ElementA *Activations, const ElementB *Weights,
       prev_group = curr_group;
 
       ElementA *ptr_A_curr_batch =
-          const_cast<ElementA *>(Activations) + cumulative_M * K;
+          const_cast<ElementA *>(Activations) + int64_t(cumulative_M) * K;
       ElementB *ptr_B_curr_batch =
-          const_cast<ElementB *>(Weights) + curr_group * K * N;
-      ElementD *ptr_D_curr_batch = Outputs + cumulative_M * N;
+          const_cast<ElementB *>(Weights) + int64_t(curr_group) * K * N;
+      ElementD *ptr_D_curr_batch = Outputs + int64_t(cumulative_M) * N;
 
       A_tensor = make_moe_tensor<ElementA, LayoutKindA>(ptr_A_curr_batch, M, K);
       B_tensor =


### PR DESCRIPTION
## Description
The MoE GEMM example crashes with Failed to allocate memory when num_experts * N * K > 2^31 (~2.1 billion elements). This happens with real MoE configurations like DeepSeek V4-Pro (384 experts, N=3072, K=7168) and DeepSeek V4-Flash (256 experts, N=2048, K=4096) - both overflow int32 in buffer size and pointer offset computations.

FIx:
Cast the first operand to int64_t (host) or int64_t (device) to promote the entire multiplication chain to 64-bit. Same pattern applied to verification pointer offsets.



## Type
- [ x] Bug  - [ x] Feature  - [ ] Performance  - [ ] Refactor

## Testing
- [x ] Tests pass  - [ ] Xe12  - [ x] Xe20
- 
Tested on BMG-G31 (32 GB) with DeepSeek V4-Pro (384 experts) and V4-Flash (256 experts), all 4 workloads now run successfully (6–9 TFLOPS)

## Performance
No performance impact - the int64_t casts are in per-group-change pointer setup, not in the DPAS hot path

## Checklist
- [ x] Copyright  - [ ] Co-pilot Review  - [ ] Deprecated APIs not used
