### PR TITLE
[Bug Fix]fix rem mask of SDPA

### DIFF
--- a/applications/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
+++ b/applications/flash_attention_v2/collective/xe_fmha_fwd_mainloop.hpp
@@ -135,6 +135,7 @@ struct FMHAFwdMainloop<XeDefault<Stages>, CausalMask_, CachedKV_, PagedKV_,
 
   using FragS = FragC<TiledMMAQK>;
   using FragSRow = decltype(reduce<1>(FragS{}, sycl::plus<void>{}));
+  using FragSCol = decltype(reduce<0>(FragS{}, sycl::plus<void>{}));
   using ElementS = typename TiledMMAQK::ValTypeD;
 
   using SingleFragA = FragC<TiledMMAPV>;                          // (atom val,q',v')
@@ -390,7 +391,7 @@ struct FMHAFwdMainloop<XeDefault<Stages>, CausalMask_, CachedKV_, PagedKV_,
       /* k masking for remainder tiles */
       if constexpr (!is_cache) {
         if (check_remainder_k && K == total_blk - 1) {
-          FragSRow k_rem_mask;
+          FragSCol k_rem_mask;
           int k_val = get<0>(tKgK_cur(0,0,0,k_idx,0)) + kblocks_cache * get<1>(TileShapeQK{});
           int k = k_val + get_sub_group().get_local_id()[0];
           CUTLASS_PRAGMA_UNROLL


### PR DESCRIPTION
## Accuracy Validation

I validated the accuracy impact using a real CogVideoX SDPA dump:

`SageAttention-Fork/example/videos/cogvideox-2b/sdpa_torch_dump_call0.pt`

The captured SDPA input shape is:

- `q/k/v = (2, 30, 17776, 64)`
- `seq_kv = 17776`, which is not divisible by `64`, so it hits the KV remainder tile path fixed by this patch.

Comparison: `ARK.sdpa` output vs the dumped torch SDPA output:

| Version | Max abs diff | Mean abs diff | `allclose(atol=1e-2, rtol=1e-2)` |
|---|---:|---:|---|
| Before fix | `0.111328125` | `0.0001224272` | `False` |
| After fix | `0.001953125` | `0.00000186265` | `True` |

Accuracy improvement on this real CogVideoX case:

- Max absolute error: `0.1113 -> 0.00195`, about `57x` lower.
- Mean absolute error: `1.224e-4 -> 1.863e-6`, about `66x` lower.

## Root Cause

The KV remainder mask was built with a row-reduced fragment (`FragSRow`), but it is applied with `broadcast<1>(...)`, which broadcasts along the K/column dimension.

Therefore, the mask fragment must be column-reduced (`FragSCol`). Using `FragSRow` incorrectly masks rows in the final partial KV tile, causing accuracy mismatches whenever `seq_len_kv` is not a multiple of the QK tile K dimension.

Before:
<img width="758" height="417" alt="image" src="https://github.com/user-attachments/assets/03fd371d-ee15-4d72-ab92-7818cfec0dec" />
After:
<img width="757" height="400" alt="image" src="https://github.com/user-attachments/assets/4304f46e-b73e-41e4-9db6-855bad4b341e" />

