### PR TITLE
Fix register spills in XeRowBroadcast/XeColBroadcast by removing full…

### DIFF
--- a/include/cutlass/epilogue/fusion/xe_visitor.hpp
+++ b/include/cutlass/epilogue/fusion/xe_visitor.hpp
@@ -822,38 +822,14 @@ struct XeRowBroadcast {
     ConsumerStoreCallbacks(MRow mRow_, CTensor tCcRow_, Params const& params_)
       : mRow(mRow_),
         tCcRow(tCcRow_),
-        params(params_),
-        tCrRow(make_fragment_like<ElementCompute>(tCcRow)) {  // Allocate register storage matching coordinate layout
-      if (EnableNullptr && params.ptr_row == nullptr) {
-        fill(tCrRow, params.null_default);
-      }
-    }
+        params(params_) { }
 
-    MRow mRow;                                                                         // Global bias tensor (M, N) - pointer already offset to correct batch
-    CTensor tCcRow;                                                                    // Global output coordinates per thread
-    decltype(make_fragment_like<ElementCompute>(tCcRow)) tCrRow;                     // Register cache: bias values pre-loaded in begin(), indexed same as tCcRow
+    MRow mRow;
+    CTensor tCcRow;
     Params const& params;
 
     CUTLASS_DEVICE void
-    begin() {
-      if (EnableNullptr && params.ptr_row == nullptr) {
-        return;
-      }
-      
-      // Load all bias values from global memory into registers once per epilogue tile.
-      // Subsequent visit() calls read from tCrRow
-      // Uses scalar loads indexed by global N coordinates from tCcRow
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < size(tCcRow); ++i) {
-        auto coord = tCcRow(i);
-        int n_coord = get<1>(coord);  // Extract global column index
-        if (n_coord < get<1>(shape(mRow))) {
-          tCrRow(i) = ElementCompute(mRow(_0{}, n_coord));  // mRow: stride_M=0 (broadcast), stride_N=1
-        } else {
-          tCrRow(i) = ElementCompute(0);  // Zero-pad out-of-bounds (for non-tile-aligned N)
-        }
-      }
-    }
+    begin() { }
 
     template <typename ElementAccumulator, int FragmentSize>
     CUTLASS_DEVICE Array<ElementCompute, FragmentSize>
@@ -868,14 +844,18 @@ struct XeRowBroadcast {
         return frg_row;
       }
 
-      // Read from pre-loaded register cache
-      // Slice tCrRow by epilogue iteration (epi_m, epi_n)
-      Tensor tCrRow_mn = tCrRow(_,_,_,epi_m,epi_n);
-      
+      Tensor tCcRow_mn = tCcRow(_,_,_,epi_m,epi_n);
+
       CUTLASS_PRAGMA_UNROLL
       for (int i = 0; i < FragmentSize; ++i) {
         int idx = epi_v * FragmentSize + i;
-        frg_row[i] = tCrRow_mn(idx);
+        auto coord = tCcRow_mn(idx);
+        int n_coord = get<1>(coord);
+        if (n_coord < get<1>(shape(mRow))) {
+          frg_row[i] = ElementCompute(mRow(_0{}, n_coord));
+        } else {
+          frg_row[i] = ElementCompute(0);
+        }
       }
 
       return frg_row;
@@ -1043,38 +1023,14 @@ struct XeColBroadcast {
     ConsumerStoreCallbacks(MCol mCol_, CTensor tCcCol_, Params const& params_)
       : mCol(mCol_),
         tCcCol(tCcCol_),
-        params(params_),
-        tCrCol(make_fragment_like<ElementCompute>(tCcCol)) {  // Allocate register storage matching coordinate layout
-      if (EnableNullptr && params.ptr_col == nullptr) {
-        fill(tCrCol, params.null_default);
-      }
-    }
+        params(params_) { }
 
-    MCol mCol;                                                                         // Global bias tensor (M, N) - pointer already offset to correct batch
-    CTensor tCcCol;                                                                    // Global output coordinates per thread
-    decltype(make_fragment_like<ElementCompute>(tCcCol)) tCrCol;                     // Register cache: bias values pre-loaded in begin(), indexed same as tCcCol
+    MCol mCol;
+    CTensor tCcCol;
     Params const& params;
 
     CUTLASS_DEVICE void
-    begin() {
-      if (EnableNullptr && params.ptr_col == nullptr) {
-        return;
-      }
-      
-      // Load all bias values from global memory into registers once per epilogue tile.
-      // Subsequent visit() calls read from tCrCol
-      // Uses scalar loads indexed by global M coordinates from tCcCol
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < size(tCcCol); ++i) {
-        auto coord = tCcCol(i);
-        int m_coord = get<0>(coord);  // Extract global row index
-        if (m_coord < get<0>(shape(mCol))) {
-          tCrCol(i) = ElementCompute(mCol(m_coord, _0{}));  // mCol: stride_M=1, stride_N=0 (broadcast)
-        } else {
-          tCrCol(i) = ElementCompute(0);  // Zero-pad out-of-bounds (for non-tile-aligned M)
-        }
-      }
-    }
+    begin() { }
 
     template <typename ElementAccumulator, int FragmentSize>
     CUTLASS_DEVICE Array<ElementCompute, FragmentSize>
@@ -1089,14 +1045,18 @@ struct XeColBroadcast {
         return frg_col;
       }
 
-      // Read from pre-loaded register cache
-      // Slice tCrCol by epilogue iteration (epi_m, epi_n)
-      Tensor tCrCol_mn = tCrCol(_,_,_,epi_m,epi_n);
-      
+      Tensor tCcCol_mn = tCcCol(_,_,_,epi_m,epi_n);
+
       CUTLASS_PRAGMA_UNROLL
       for (int i = 0; i < FragmentSize; ++i) {
         int idx = epi_v * FragmentSize + i;
-        frg_col[i] = tCrCol_mn(idx);
+        auto coord = tCcCol_mn(idx);
+        int m_coord = get<0>(coord);
+        if (m_coord < get<0>(shape(mCol))) {
+          frg_col[i] = ElementCompute(mCol(m_coord, _0{}));
+        } else {
+          frg_col[i] = ElementCompute(0);
+        }
       }
 
       return frg_col;


### PR DESCRIPTION
…-tile register cache

## Description
XeRowBroadcast and XeColBroadcast pre-loaded all broadcast values into
a register cache (tCrRow/tCrCol) in begin(), sized to the full
per-thread tile partition: (mma_v × mma_m × mma_n × epi_m × epi_n).

For a 256×256 tile with subgroup size 16 and MMA atom 8×16, this
allocates 4096 floats (16KB) per thread — double the 8KB GRF budget
(256 registers × 32 bytes) on Xe2 with 256-GRF mode. The redundancy
is 16×: ColBroadcast replicates the same M-indexed value across all
N positions, but stores a separate copy for each.

This caused 12–22 register spills across all epilogue visitor
configurations at 256×256 tiles, with no way to avoid them from
user code.

Replace the full-tile register cache with direct global memory loads
in visit(). The broadcast vector is small (≤tile_dim floats) and
remains L1-cached after first access, so repeated scalar loads have
negligible latency.

**Note**: this assumes scale/bias and D don't alias, which is guaranteed by the CUTLASS API contract (separate Arguments fields for each pointer).

## Type
- [ x] Bug  - [ ] Feature  - [ ] Performance  - [ ] Refactor

## Testing
- [ x] Tests pass  - [ ] Xe12  - [ x] Xe20

All tests are passing 

```
[----------] Global test environment tear-down
[==========] 62 tests from 46 test suites ran. (169546 ms total)
[  PASSED  ] 62 tests.

```

## Performance
Tested on BMG (Xe2) with IGC 256-GRF mode at 256×256×32 tiles:

| Kernel | Spills (before → after) | TFlop/s (before → after) |
|---|---:|---:|
| ScaleRows | 22 → 0 | 137.6 → 149.0 (+8.3%) |
| SwiGLU | 15 → 0 | 133.1 → 139.5 (+4.8%) |
| GeGLU | 12 → 0 | 131.8 → 138.4 (+5.0%) |
| RoPEScaled | 21 → 0 | 122.2 → 129.3 (+5.8%) |

Benchmarked at 4096×4096×4096 (bf16, 200 iterations). Smaller tiles
(128×256, 256×128, 128×128) already had 0 spills and are unaffected.
XeColReduction/XeRowReduction are unchanged — they use their own
tCrCol/tCrRow for accumulation and are not affected by this change.


## References
Fixes #

## Checklist
- [x] Copyright  - [ ] Co-pilot Review  - [x] Deprecated APIs not used
