### PR TITLE
Add SYCL subgroup lane index to canonical_lane_idx()

### DIFF
--- a/include/cutlass/cutlass.h
+++ b/include/cutlass/cutlass.h
@@ -110,15 +110,29 @@ CUTLASS_HOST_DEVICE bool thread0() {
   #endif
 }
 
+#if defined(SYCL_INTEL_TARGET)
+CUTLASS_DEVICE
+auto get_sub_group_id() {
+  return sycl::ext::oneapi::this_work_item::get_nd_item<3>()
+                    .get_sub_group()
+                    .get_group_id()[0];
+}
+
+CUTLASS_DEVICE
+auto get_sub_group_local_id() {
+  return sycl::ext::oneapi::this_work_item::get_nd_item<3>()
+                    .get_sub_group()
+                    .get_local_id()[0];
+}
+#endif
+
 /// Returns a lane index in the warp/subgroup. The threads in warp may not be convergent
 CUTLASS_DEVICE
 int canonical_lane_idx() {
   #if defined(__CUDA_ARCH__)
     return threadIdx.x % NumThreadsPerWarp;
-  #elif defined(__SYCL_DEVICE_ONLY__)
-    return sycl::ext::oneapi::this_work_item::get_nd_item<3>()
-                      .get_sub_group()
-                      .get_local_id()[0];
+  #elif defined(SYCL_INTEL_TARGET)
+    return get_sub_group_local_id();
   #else
     return 0;
   #endif
@@ -127,7 +141,7 @@ int canonical_lane_idx() {
 /// Returns a warp-uniform value indicating the canonical warp index of the calling threads.
 /// Threads within the warp must be converged.
 CUTLASS_DEVICE
-int canonical_warp_idx_sync() { 
+int canonical_warp_idx_sync() {
   #if defined(__CUDA_ARCH__)
     return __shfl_sync(0xffffffff, threadIdx.x / NumThreadsPerWarp, 0);
   #else
@@ -138,7 +152,7 @@ int canonical_warp_idx_sync() {
 /// Returns a warp index in the CTA. The threads in warp may not be convergent
 /// As it doesn't sync the warp, it faster and allows forward progress
 CUTLASS_DEVICE
-int canonical_warp_idx() { 
+int canonical_warp_idx() {
   #if defined(__CUDA_ARCH__)
     return threadIdx.x / NumThreadsPerWarp;
   #else
@@ -156,22 +170,6 @@ int canonical_warp_group_idx() {
     return 0;
   #endif
 }
-
-#if defined(SYCL_INTEL_TARGET)
-CUTLASS_DEVICE
-auto get_sub_group_id() {
-  return sycl::ext::oneapi::this_work_item::get_nd_item<3>()
-                    .get_sub_group()
-                    .get_group_id()[0];
-}
-
-CUTLASS_DEVICE
-auto get_sub_group_local_id() {
-  return sycl::ext::oneapi::this_work_item::get_nd_item<3>()
-                    .get_sub_group()
-                    .get_local_id()[0];
-}
-#endif
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 }  // namespace cutlass

--- a/include/cutlass/cutlass.h
+++ b/include/cutlass/cutlass.h
@@ -110,11 +110,15 @@ CUTLASS_HOST_DEVICE bool thread0() {
   #endif
 }
 
-/// Returns a lane index in the warp. The threads in warp may not be convergent
+/// Returns a lane index in the warp/subgroup. The threads in warp may not be convergent
 CUTLASS_DEVICE
-int canonical_lane_idx() { 
+int canonical_lane_idx() {
   #if defined(__CUDA_ARCH__)
     return threadIdx.x % NumThreadsPerWarp;
+  #elif defined(__SYCL_DEVICE_ONLY__)
+    return sycl::ext::oneapi::this_work_item::get_nd_item<3>()
+                      .get_sub_group()
+                      .get_local_id()[0];
   #else
     return 0;
   #endif


### PR DESCRIPTION
## Description
canonical_lane_idx() was missing the SYCL device path, causing all
threads to fall through to the #else branch and return 0. This means
every lane in a subgroup reports itself as lane 0 on Intel Xe GPUs.

This breaks XeColReduction and XeRowReduction in xe_visitor.hpp,
which use canonical_lane_idx() to compute each lane's position in the
reduction layout (lane_mn mapping). With all
lanes returning 0, the reduction coordinates are incorrect.

Add the __SYCL_DEVICE_ONLY__ path using the standard SYCL subgroup
local ID query, matching the pattern already used elsewhere in the
codebase (e.g., thread0()).


## Type
- [x] Bug  - [ ] Feature  - [ ] Performance  - [ ] Refactor

## Testing
- [x ] Tests pass  - [ ] Xe12  - [ x] Xe20
Tested on BMG (Xe2, Arc Pro B70):
  - Direct lane index verification: 4 subgroups x 16 lanes, all
    indices correct and distinct per subgroup
  - EVT epilogue fusion tests: 4/4 passed (LinCombEltAct, dReLU,
    LinCombPerRowBias, LinCombPerColBias)

## Performance
No difference 

## References
Fixes #

## Checklist
- [x] Copyright  - [ ] Co-pilot Review  - [ x] Deprecated APIs not used
