### PR TITLE
Fix NumericConverter for SYCL device code (float→int32/int8/uint8)

### DIFF
--- a/include/cutlass/numeric_conversion.h
+++ b/include/cutlass/numeric_conversion.h
@@ -108,7 +108,8 @@ struct NumericConverter<int32_t, float, FloatRoundStyle::round_to_nearest> {
     #if __CUDA_ARCH__
     return __float2int_rn(s);
     #elif defined(__SYCL_DEVICE_ONLY__)
-    return static_cast<result_type>(sycl::rint(s));
+    // rintf and sycl::rint compile to the same rnde instruction
+    return static_cast<result_type>(rintf(s));
     #elif !defined(__CUDACC_RTC__)
     std::fesetround(FE_TONEAREST);
     return static_cast<result_type>(std::nearbyint(s));
@@ -166,7 +167,7 @@ struct NumericConverter<int8_t, float, FloatRoundStyle::round_to_nearest> {
     asm volatile("cvt.rni.sat.s8.f32 %0, %1;" : "=r"(intermediate) : "f"(s));
     return static_cast<result_type>(intermediate);
     #elif defined(__SYCL_DEVICE_ONLY__)
-    int32_t intermediate = static_cast<int32_t>(sycl::rint(s));
+    int32_t intermediate = static_cast<int32_t>(rintf(s));
     intermediate = sycl::max(intermediate, (int32_t)std::numeric_limits<int8_t>::lowest());
     intermediate = sycl::min(intermediate, (int32_t)std::numeric_limits<int8_t>::max());
     return static_cast<result_type>(intermediate);
@@ -236,7 +237,7 @@ struct NumericConverter<uint8_t, float, FloatRoundStyle::round_to_nearest> {
     asm volatile("cvt.rni.sat.u8.f32 %0, %1;" : "=r"(intermediate) : "f"(s));
     return static_cast<result_type>(intermediate);
     #elif defined(__SYCL_DEVICE_ONLY__)
-    int32_t intermediate = static_cast<int32_t>(sycl::rint(s));
+    int32_t intermediate = static_cast<int32_t>(rintf(s));
     intermediate = sycl::max(intermediate, (int32_t)std::numeric_limits<uint8_t>::lowest());
     intermediate = sycl::min(intermediate, (int32_t)std::numeric_limits<uint8_t>::max());
     return static_cast<result_type>(intermediate);

--- a/include/cutlass/numeric_conversion.h
+++ b/include/cutlass/numeric_conversion.h
@@ -107,6 +107,8 @@ struct NumericConverter<int32_t, float, FloatRoundStyle::round_to_nearest> {
   static result_type convert(source_type const & s) {
     #if __CUDA_ARCH__
     return __float2int_rn(s);
+    #elif defined(__SYCL_DEVICE_ONLY__)
+    return static_cast<result_type>(sycl::rint(s));
     #elif !defined(__CUDACC_RTC__)
     std::fesetround(FE_TONEAREST);
     return static_cast<result_type>(std::nearbyint(s));
@@ -130,6 +132,8 @@ struct NumericConverter<int32_t, float, FloatRoundStyle::round_toward_zero> {
   static result_type convert(source_type const & s) {
     #if __CUDA_ARCH__
     return __float2int_rz(s);
+    #elif defined(__SYCL_DEVICE_ONLY__)
+    return static_cast<result_type>(sycl::trunc(s));
     #elif !defined(__CUDACC_RTC__)
     std::fesetround(FE_TOWARDZERO);
     return (result_type)std::nearbyint(s);
@@ -161,6 +165,11 @@ struct NumericConverter<int8_t, float, FloatRoundStyle::round_to_nearest> {
     int32_t intermediate;
     asm volatile("cvt.rni.sat.s8.f32 %0, %1;" : "=r"(intermediate) : "f"(s));
     return static_cast<result_type>(intermediate);
+    #elif defined(__SYCL_DEVICE_ONLY__)
+    int32_t intermediate = static_cast<int32_t>(sycl::rint(s));
+    intermediate = sycl::max(intermediate, (int32_t)std::numeric_limits<int8_t>::lowest());
+    intermediate = sycl::min(intermediate, (int32_t)std::numeric_limits<int8_t>::max());
+    return static_cast<result_type>(intermediate);
     #elif !defined(__CUDACC_RTC__)
     std::fesetround(FE_TONEAREST);
     int32_t intermediate = (int32_t)std::nearbyint(s);
@@ -191,6 +200,11 @@ struct NumericConverter<int8_t, float, FloatRoundStyle::round_toward_zero> {
     int32_t intermediate;
     asm volatile("cvt.rzi.sat.s8.f32 %0, %1;" : "=r"(intermediate) : "f"(s));
     return static_cast<result_type>(intermediate);
+    #elif defined(__SYCL_DEVICE_ONLY__)
+    int32_t intermediate = static_cast<int32_t>(sycl::trunc(s));
+    intermediate = sycl::max(intermediate, (int32_t)std::numeric_limits<int8_t>::lowest());
+    intermediate = sycl::min(intermediate, (int32_t)std::numeric_limits<int8_t>::max());
+    return static_cast<result_type>(intermediate);
     #elif !defined(__CUDACC_RTC__)
     std::fesetround(FE_TOWARDZERO);
     int32_t intermediate = (int32_t)std::nearbyint(s);
@@ -199,7 +213,7 @@ struct NumericConverter<int8_t, float, FloatRoundStyle::round_toward_zero> {
     // High-end saturation
     intermediate = std::min(intermediate, (int32_t)std::numeric_limits<int8_t>::max());
     return static_cast<result_type>(intermediate);
-    #endif 
+    #endif
   }
 
   CUTLASS_HOST_DEVICE
@@ -220,6 +234,11 @@ struct NumericConverter<uint8_t, float, FloatRoundStyle::round_to_nearest> {
     #if defined(__CUDA_ARCH__)
     int32_t intermediate;
     asm volatile("cvt.rni.sat.u8.f32 %0, %1;" : "=r"(intermediate) : "f"(s));
+    return static_cast<result_type>(intermediate);
+    #elif defined(__SYCL_DEVICE_ONLY__)
+    int32_t intermediate = static_cast<int32_t>(sycl::rint(s));
+    intermediate = sycl::max(intermediate, (int32_t)std::numeric_limits<uint8_t>::lowest());
+    intermediate = sycl::min(intermediate, (int32_t)std::numeric_limits<uint8_t>::max());
     return static_cast<result_type>(intermediate);
     #elif !defined(__CUDACC_RTC__)
     std::fesetround(FE_TONEAREST);
@@ -250,6 +269,11 @@ struct NumericConverter<uint8_t, float, FloatRoundStyle::round_toward_zero> {
     #if __CUDA_ARCH__
     int32_t intermediate;
     asm volatile("cvt.rzi.sat.u8.f32 %0, %1;" : "=r"(intermediate) : "f"(s));
+    return static_cast<result_type>(intermediate);
+    #elif defined(__SYCL_DEVICE_ONLY__)
+    int32_t intermediate = static_cast<int32_t>(sycl::trunc(s));
+    intermediate = sycl::max(intermediate, (int32_t)std::numeric_limits<uint8_t>::lowest());
+    intermediate = sycl::min(intermediate, (int32_t)std::numeric_limits<uint8_t>::max());
     return static_cast<result_type>(intermediate);
     #elif !defined(__CUDACC_RTC__)
     std::fesetround(FE_TOWARDZERO);

--- a/include/cutlass/numeric_conversion.h
+++ b/include/cutlass/numeric_conversion.h
@@ -108,7 +108,6 @@ struct NumericConverter<int32_t, float, FloatRoundStyle::round_to_nearest> {
     #if __CUDA_ARCH__
     return __float2int_rn(s);
     #elif defined(__SYCL_DEVICE_ONLY__)
-    // rintf and sycl::rint compile to the same rnde instruction
     return static_cast<result_type>(rintf(s));
     #elif !defined(__CUDACC_RTC__)
     std::fesetround(FE_TONEAREST);


### PR DESCRIPTION
## Description
* Add __SYCL_DEVICE_ONLY__ paths to NumericConverter specializations for float → int32_t, float → int8_t, and float → uint8_t (both round_to_nearest and round_toward_zero variants)
* The existing host paths use std::fesetround() and std::nearbyint() from <cfenv>, which are not available in SYCL device code — this caused compilation failures when these converters were instantiated (e.g. INT8 GEMM with int32 output via LinearCombination)
* SYCL paths use sycl::rint() / sycl::trunc() and sycl::min() / sycl::max() for saturation

**BTW, This is the last patch I need for some of my current work. I already contributed a couple of related patches, and this should complete the remaining part.**

## Type
- [x] Bug  - [ ] Feature  - [ ] Performance  - [ ] Refactor

## Testing
- [x] Tests pass  - [ ] Xe12  - [x] Xe20

## Performance
This patch enables INT8 GEMM with native int32 output on Xe, which avoids unnecessary int32→float conversion. Benchmarked on Intel Arc Pro B70 (BMG, peak INT8 = 367 TOPS):

| Kernel | 4096³ | 2048×4096² | 4096×4096×8192 |
|---|---|---|---|
| INT8 bare → int32 **(new)** | 235.9 TOPs | 213.8 TOPs | 268.2 TOPs |
| INT8 bare → float (workaround) | 220.8 TOPs | 192.3 TOPs | 270.5 TOPs |
| PyTorch `_int_mm` (oneMKL) | 267.0 TOPs | 265.7 TOPs | 273.8 TOPs |

## References
Fixes #

## Checklist
- [x] Copyright  - [ ] Co-pilot Review  - [x] Deprecated APIs not used
