### PR TITLE
Fix average runtime and GFLOPS calculation in example 10

### DIFF
--- a/examples/10_bmg_grouped_gemm_mixed_dtype/bmg_grouped_gemm_mixed_dtype_runner.hpp
+++ b/examples/10_bmg_grouped_gemm_mixed_dtype/bmg_grouped_gemm_mixed_dtype_runner.hpp
@@ -947,7 +947,7 @@ struct ExampleRunner {
       }
       compat::wait();
 
-      float cute_time = timer.seconds() / options.iterations;
+      float cute_time = timer.seconds() * 1000;
       double cute_average_time = double(cute_time) / double(options.iterations);
       double gflops = options.gflops(cute_average_time / 1000.0, options.problem_sizes_host);
 


### PR DESCRIPTION
## Description

Fix the timing calculation in example 10.

Previously, the measured total runtime from `timer.seconds()` was divided by
`options.iterations` twice:

1. once when assigning `cute_time`
2. again when computing `cute_average_time`

In addition, `cute_average_time` was later divided by `1000.0` when calculating
GFLOPS, even though the previous value was already based on seconds.

This caused the reported average runtime to be too small and the reported GFLOPS
to be too large. With the default `--iterations=100`, the GFLOPS value could be
inflated by `1000 * iterations`, i.e. 100,000x.

The fix converts total elapsed seconds to milliseconds first, then divides once
by the iteration count to report average runtime in ms. GFLOPS calculation then
converts the average runtime back to seconds.

## Type

- [x] Bug
- [ ] Feature
- [ ] Performance
- [ ] Refactor

## Testing

- [ ] Tests pass
- [ ] Xe12
- [ ] Xe20

## Performance

| Metric | Before | After |
|--------|--------|-------|
|||
|||

## References

Fixes #

## Checklist

- [ ] Copyright
- [ ] Co-pilot Review
- [ ] Deprecated APIs not used