### PR TITLE
ci: self-heal DPC++ install when sycl-ls is missing on BMG runners

### DIFF
--- a/.github/actions/install-dpcpp/action.yml
+++ b/.github/actions/install-dpcpp/action.yml
@@ -112,10 +112,21 @@ runs:
       if: inputs.DPCPP_RELEASE == 'TORCH_SUPPORTED'
       shell: bash
       run: |
-        if [ -d /home/ghrunner/intel/oneapi/compiler ]; then
-          echo "DPC++ compiler already installed at /home/ghrunner/intel/oneapi/compiler"
+        # Verify a *working* DPC++ install rather than just the directory's
+        # existence: on the persistent self-hosted runners the oneAPI tree can
+        # drift (e.g. sycl-ls dropped from compiler/<ver>/bin), and a bare
+        # `[ -d .../compiler ]` guard would keep reusing the broken toolchain,
+        # making the later `sycl-ls` step fail with exit code 127.
+        dpcpp_ok=false
+        if [ -f /home/ghrunner/intel/oneapi/setvars.sh ]; then
+          if ( . /home/ghrunner/intel/oneapi/setvars.sh > /dev/null 2>&1 && command -v sycl-ls > /dev/null 2>&1 ); then
+            dpcpp_ok=true
+          fi
+        fi
+        if [ "$dpcpp_ok" = "true" ]; then
+          echo "DPC++ compiler already installed and sycl-ls is available"
         else
-          echo "Installing DPC++ compiler..."
+          echo "DPC++ compiler missing or broken (sycl-ls not found) - (re)installing..."
           sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/b3e6c1bf-a6d5-4580-8b1d-80cbfd38c8af/intel-deep-learning-essentials-2025.3.2.36_offline.sh
           bash intel-deep-learning-essentials-2025.3.2.36_offline.sh -a --silent --eula accept --components intel.oneapi.lin.dpcpp-cpp-compiler
         fi


### PR DESCRIPTION
## Problem

The **SYCL Python EVT Test** workflow has failed on every run since 2026-06-15 (last success 2026-06-12, e.g. run `27530386185`, latest `27648163476`). The job dies at the **Setup virtual environment** step:

```
/runners/.../*.sh: line 6: sycl-ls: command not found
##[error]Process completed with exit code 127.
```

## Root cause

This is **environment drift on the persistent self-hosted BMG runners**, not a code regression — the workflow and `install-dpcpp` action are unchanged since #785 (2026-04-29). Comparing the last good run (06-12) to the failures:

| | Success 06-12 | Failures 06-15/16 |
|---|---|---|
| oneAPI modules from `setvars.sh` | compiler, **debugger, dpl**, dev-utilities, pti, tbb, umf | compiler, dev-utilities, **mkl, mpi**, pti, tbb, umf |
| `sycl-ls` after sourcing | ✅ lists BMG GPU | ❌ command not found |

The `/home/ghrunner/intel/oneapi` install drifted and `sycl-ls` is gone from `compiler/<ver>/bin`. The same signature reproduces on at least two runners in the pool (`bmgvm2` and `vm01`), so it is fleet-wide rather than a one-off.

The `TORCH_SUPPORTED` branch of `.github/actions/install-dpcpp/action.yml` guards (re)install with:

```bash
if [ -d /home/ghrunner/intel/oneapi/compiler ]; then
  echo "DPC++ compiler already installed ..."
```

Because the directory still exists, the action logs *"already installed"* and **never repairs** the broken toolchain — so CI can't self-recover.

## Fix

Replace the directory-existence guard with a **functional check**: source `setvars.sh` and confirm `sycl-ls` is actually on `PATH`; reinstall DPC++ only if that check fails. This makes the action self-heal on any drifted runner and is a no-op on healthy ones.

> Note: the runner fleet should still be repaired at the source; this change makes CI resilient to such drift going forward.

## Validation

- `yaml.safe_load` parses the action file cleanly.
- `bash -n` passes on the modified step script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
