### PR TITLE
Fix bare `ushort` in host-context templates on Windows

### DIFF
--- a/include/cute/arch/mma_xe_legacy_spirv.hpp
+++ b/include/cute/arch/mma_xe_legacy_spirv.hpp
@@ -44,7 +44,7 @@ SYCL_EXTERNAL               int __spirv_SubgroupMatrixMultiplyAccumulateINTEL(in
 SYCL_EXTERNAL cute::intel::int8 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::ushort8, cute::intel::uint8, cute::intel::int8, int32_t);
 SYCL_EXTERNAL cute::intel::int4 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::ushort4, cute::intel::uint8, cute::intel::int4, int32_t);
 SYCL_EXTERNAL cute::intel::int2 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::ushort2, cute::intel::uint8, cute::intel::int2, int32_t);
-SYCL_EXTERNAL               int __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t,               ushort, cute::intel::uint8,               int, int32_t);
+SYCL_EXTERNAL               int __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t,               unsigned short, cute::intel::uint8,               int, int32_t);
 
 SYCL_EXTERNAL cute::intel::float8 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::float4, cute::intel::float8, cute::intel::float8, int32_t);
 SYCL_EXTERNAL cute::intel::float4 __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, cute::intel::float2, cute::intel::float8, cute::intel::float4, int32_t);

--- a/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp
+++ b/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp
@@ -432,7 +432,7 @@ public:
     static constexpr auto N = decltype(size<1>(in))::value;
     static constexpr auto K = decltype(size<2>(in))::value;
 
-    using format_type = ushort;
+    using format_type = unsigned short;
     static constexpr auto src_bits = sizeof_bits_v<SrcType>;
     static constexpr auto scalar = sizeof_bits_v<format_type> / src_bits;
     static constexpr auto loop_cnt = decltype(size(out))::value / N;


### PR DESCRIPTION
## Description

Bare `ushort` is an OpenCL C builtin — defined by the SYCL headers only during **device** compilation. Two sites in the codebase use bare `ushort` in host-context template instantiation, where the identifier is undefined, blocking host-side C++ compilation on Windows (icx or cl.exe):

```
error: unknown type name 'ushort'
   47 | SYCL_EXTERNAL int __spirv_SubgroupMatrixMultiplyAccumulateINTEL(int32_t, ushort, cute::intel::uint8, int, int32_t);
      |                                                                 ^
```

Both sites already have the equivalent namespaced form `cute::intel::ushort` in scope, which is `typedef unsigned short`. Replacing the bare token with the explicit `unsigned short` is a **strict no-op on Linux SYCL host compilation** (OpenCL C typedefs make them equivalent) and lets the Windows host compiler resolve the type.

## Type

- [x] Bug

## Changes

- `include/cute/arch/mma_xe_legacy_spirv.hpp` (line 47) — parameter type in a `SYCL_EXTERNAL __spirv_SubgroupMatrixMultiplyAccumulateINTEL` overload. The three surrounding overloads correctly use `cute::intel::ushort2/4/8`; this one was inconsistent.
- `include/cutlass/gemm/collective/xe_mma_mixed_input.hpp` (line 435) — `using format_type = ushort;` in a host-side helper. Changed to `unsigned short`.

Two lines, one line per file.

## Testing

- [x] Tests pass
- [x] Xe20 (BMG)
- [ ] Xe12

Compilation verified via `intel/intel-xpu-backend-for-triton` benchmarks build (`sycl_tla_kernel.pyd`) on Windows 11 + Intel oneAPI 2026 + MSVC 14.44 + Python 3.10 targeting Intel Arc B570 (BMG / Xe2). Before this fix, the build failed at the `ushort` sites; after, the SYCL-TLA library compiles fully and the `sycl_tla_kernel.pyd` module (~3 MB) exposes real `gemm`, `gemm_splitk`, `attention` symbols.

flex-attention-causal benchmark reaches the sycl-tla compute path with these fixes in place (verified end-to-end).

## Performance

No performance impact — this is a compile-time type substitution that resolves to the same underlying `unsigned short` type on all platforms.

## References

Discovered while porting the benchmark suite of intel/intel-xpu-backend-for-triton to native Windows (see intel/intel-xpu-backend-for-triton#7375 for a downstream workaround via `patches/` that shipping this fix would render unnecessary).

## Checklist

- [x] Copyright — no new files; existing headers untouched
- [ ] Co-pilot Review
- [x] Deprecated APIs not used
