### PR TITLE
[XE2] Widen D-store to full cache line for small-K GEMM

### DIFF
--- a/examples/cute/tutorial/xe_gemm.cpp
+++ b/examples/cute/tutorial/xe_gemm.cpp
@@ -96,6 +96,7 @@ gemm_device(ATensor   const& A,         // (M,K)
   auto thr_mma    =    mma.get_slice(local_id);
   auto thr_copy_a = copy_a.get_slice(local_id);
   auto thr_copy_b = copy_b.get_slice(local_id);
+  auto thr_copy_c = copy_c.get_slice(local_id);
 
   /* Register fragments for MMA */
   auto tCrA = thr_mma.partition_sg_fragment_A(gA(_,_,0));
@@ -109,9 +110,12 @@ gemm_device(ATensor   const& A,         // (M,K)
   Tensor tAgA = thr_copy_a.partition_S(gA);
   Tensor tBgB = thr_copy_b.partition_S(gB);
 
-  /* Partition C */
-  Tensor tCrC = partition_fragment_C(mma, select<0,1>(wg_tile));
-  Tensor tCgC = thr_mma.partition_C(gC);    /* also matches copy_c's source layout */
+  /* Partition C.  The accumulator carries the MMA-C layout; the store fragment/tensor
+     come from the store copy (copy_c) so the store atom's width can differ from a
+     single MMA N-atom.  reorder() bridges the MMA-C layout to the store layout. */
+  auto tCrC = thr_mma.partition_sg_fragment_C(gC);
+  auto tCrD = thr_copy_c.partition_sg_fragment_S(gC);
+  auto tCgC = thr_copy_c.partition_D(gC);
 
   /* Create prefetch TiledCopy instances */
   auto prefetch_a = make_block_2d_prefetch(copy_a);
@@ -170,8 +174,10 @@ gemm_device(ATensor   const& A,         // (M,K)
     barrier_wait(barrier_scope);
   }
 
-  /* Write C to global memory */
-  copy(copy_c, tCrC, tCgC);
+  /* Write C to global memory: reorder the accumulator into the store's register
+     layout, then store (handles store atoms wider than one MMA N-atom). */
+  reorder(tCrC, tCrD);
+  copy(copy_c, tCrD, tCgC);
 }
 
 template <typename TA, typename TB, typename TC>

--- a/examples/cute/tutorial/xe_gemm_quantization.cpp
+++ b/examples/cute/tutorial/xe_gemm_quantization.cpp
@@ -121,9 +121,13 @@ gemm_device(ATensor   const& A,         // (M,K)
   Tensor tAgA = thr_copy_a.partition_S(gA);
   Tensor tBgB = thr_copy_b.partition_S(gB);
 
-  /* Partition C */
+  /* Partition C.  Accumulator carries the MMA-C layout; the store fragment/tensor come
+     from the store copy (copy_c) so its width can exceed one MMA N-atom.  reorder() below
+     bridges the MMA-C layout into the store fragment without disturbing tCrC, which is
+     reused for quantization. */
   auto tCrC = thr_mma.partition_sg_fragment_C(gC);
-  Tensor tCgC = thr_mma.partition_C(gC);    /* also matches copy_c's source layout */
+  auto tCrD = thr_copy_c.partition_sg_fragment_S(gC);
+  auto tCgC = thr_copy_c.partition_D(gC);
 
   /* Create prefetch TiledCopy instances */
   auto prefetch_a = make_block_2d_prefetch(copy_a);
@@ -183,8 +187,10 @@ gemm_device(ATensor   const& A,         // (M,K)
   }
 
   if (verify != 0) {
-    /* Write C (GEMM result) to global memory*/
-    copy(copy_c, tCrC, tCgC);
+    /* Write C (GEMM result) to global memory: reorder the accumulator into the store's
+       register layout, then store (handles store atoms wider than one MMA N-atom). */
+    reorder(tCrC, tCrD);
+    copy(copy_c, tCrD, tCgC);
   }
 
   /* Partition quantization output */

--- a/examples/cute/tutorial/xe_gemm_slm.cpp
+++ b/examples/cute/tutorial/xe_gemm_slm.cpp
@@ -186,9 +186,13 @@ gemm_device(ATensor   const& A,         // (M,K)
   Tensor tAgA = coop_thr_copy_a.partition_S(gA);
   Tensor tBgB = coop_thr_copy_b.partition_S(gB);
 
-  /* Partition C */
-  Tensor tCrC = partition_fragment_C(mma, select<0,1>(wg_tile));
-  Tensor tCgC = thr_mma.partition_C(gC);    /* also matches copy_c's source layout */
+  /* Partition C.  Accumulator carries the MMA-C layout; the store fragment/tensor come
+     from the store copy (copy_c) so its width can exceed one MMA N-atom; reorder() bridges
+     the two register layouts before the store. */
+  auto thr_copy_c = copy_c.get_slice(local_id);
+  auto tCrC = thr_mma.partition_sg_fragment_C(gC);
+  auto tCrD = thr_copy_c.partition_sg_fragment_S(gC);
+  auto tCgC = thr_copy_c.partition_D(gC);
 
   // ------
   // Kernel
@@ -239,8 +243,10 @@ gemm_device(ATensor   const& A,         // (M,K)
     }
   }
 
-  /* Write C to global memory */
-  copy(copy_c, tCrC, tCgC);
+  /* Write C to global memory: reorder the accumulator into the store's register layout,
+     then store (handles store atoms wider than one MMA N-atom). */
+  reorder(tCrC, tCrD);
+  copy(copy_c, tCrD, tCgC);
 }
 
 template <typename TA, typename TB, typename TC>

--- a/examples/cute/tutorial/xe_gemm_subgroup_specialization_slm.cpp
+++ b/examples/cute/tutorial/xe_gemm_subgroup_specialization_slm.cpp
@@ -190,9 +190,13 @@ gemm_device(ATensor   const& A,         // (M,K)
   Tensor tAgA = coop_thr_copy_a.partition_S(gA);
   Tensor tBgB = coop_thr_copy_b.partition_S(gB);
 
-  /* Partition C */
-  Tensor tCrC = partition_fragment_C(mma, select<0,1>(wg_tile));
-  Tensor tCgC = thr_mma.partition_C(gC);    /* also matches copy_c's source layout */
+  /* Partition C.  Accumulator carries the MMA-C layout; the store fragment/tensor come
+     from the store copy (copy_c) so its width can exceed one MMA N-atom; reorder() bridges
+     the two register layouts before the store. */
+  auto thr_copy_c = copy_c.get_slice(local_id);
+  auto tCrC = thr_mma.partition_sg_fragment_C(gC);
+  auto tCrD = thr_copy_c.partition_sg_fragment_S(gC);
+  auto tCgC = thr_copy_c.partition_D(gC);
 
   // ------
   // Kernel
@@ -247,8 +251,10 @@ gemm_device(ATensor   const& A,         // (M,K)
     barrier_wait(SPIRVScope::ScopeWorkgroup, SPIRVMemorySemantics::SemanticsAcquire | SPIRVMemorySemantics::SemanticsWGMemory);
   }
   if(role_id == role::consumer) {
-    /* Write C to global memory */
-    copy(copy_c, tCrC, tCgC);
+    /* Write C to global memory: reorder the accumulator into the store's register layout,
+       then store (handles store atoms wider than one MMA N-atom). */
+    reorder(tCrC, tCrD);
+    copy(copy_c, tCrD, tCgC);
   }
 }
 

--- a/examples/cute/tutorial/xe_two_gemm_fusion.cpp
+++ b/examples/cute/tutorial/xe_two_gemm_fusion.cpp
@@ -207,7 +207,11 @@ gemm_two_stage_device(ATensor   const& A,     // (M, K)
   Tensor tIrI = thr_slm_ld.retile_D(tArA_2);
   Tensor tIsI = thr_slm_ld.partition_S(SInTensor);
 
-  Tensor tCgD = thr_mma.partition_C(gD_2);
+  /* Stage-2 D store: take the store fragment/tensor from copy_d so its width can exceed
+     one MMA N-atom; reorder() bridges the accumulator's MMA-C layout into it. */
+  auto thr_copy_d = copy_d.get_slice(local_id);
+  auto tDrD = thr_copy_d.partition_sg_fragment_S(gD_2);
+  Tensor tCgD = thr_copy_d.partition_D(gD_2);
 
   auto prefetch_a = make_block_2d_prefetch(copy_a);
   auto prefetch_b = make_block_2d_prefetch(copy_b);
@@ -267,7 +271,8 @@ gemm_two_stage_device(ATensor   const& A,     // (M, K)
     gemm(mma, tCrA_2, tCrB_2, tCrAcc);
   }
 
-  copy(copy_d, tCrAcc, tCgD);
+  reorder(tCrAcc, tDrD);
+  copy(copy_d, tDrD, tCgD);
 }
 
 // ---------------------------------------------------------------------------

--- a/include/cute/atom/copy_traits_xe_2d.hpp
+++ b/include/cute/atom/copy_traits_xe_2d.hpp
@@ -1152,10 +1152,19 @@ make_block_2d_copy_D(TiledMMA           const& mma,         // TiledMMA instance
                      Stride<Strides...> const& gstride)     // Global memory strides
 {
   using MMAType = typename TiledMMA::ValTypeD;
-  auto cD = make_identity_tensor(select<0,1>(mma.tile_mnk()));
-  auto op = block_2d_selector<ValType, MMAType, true>(
-    mma.get_slice(0).atom_partition_C(cD).layout(), gstride
-  );
+  // Size the D store from the *per-subgroup output tile* rather than a single MMA-C atom.
+  // A single DPAS N-atom is only 16 elements (half a 64B cache line for 16-bit D), which
+  // halves store bandwidth and dominates small-K GEMM runtime (CUTLASS9-656).  Each
+  // subgroup owns a contiguous N run of (tile_n / sg_n) columns, so feeding the selector
+  // that sub-tile lets it size a full-cache-line store from a real coordinate tiling --
+  // no separate atom-width rewrite, and the width naturally falls back to one atom when
+  // the per-subgroup N run is itself only one atom wide.  The consumer bridges the MMA-C
+  // accumulator into this (wider) copy layout via partition_sg_fragment_S + reorder.
+  auto thr_vmnk = mma.get_thr_layout_vmnk();                                         // (ThrV,ThrM,ThrN,ThrK)
+  auto sg_tile  = shape_div(select<0,1>(mma.tile_mnk()),
+                            make_shape(size<1>(shape(thr_vmnk)), size<2>(shape(thr_vmnk))));
+  auto cD = make_identity_tensor(sg_tile);
+  auto op = block_2d_selector<ValType, MMAType, true>(cD.layout(), gstride);
   return make_block_2d_copy_CD<ValType>(op, mma, gstride);
 }
 

--- a/include/cutlass/epilogue/fusion/xe_visitor.hpp
+++ b/include/cutlass/epilogue/fusion/xe_visitor.hpp
@@ -374,8 +374,8 @@ struct XeAuxStore {
       // Block 2D copy path (explicit CopyOp or auto-deduced)
       using ActualCopyOpR2G = cute::conditional_t<
         cute::is_void_v<CopyOpR2G_>,
-        XE_STORE_2D<CopyBits, 
-                   cute::gcd(8, get<0>(MMATile{})), 
+        XE_STORE_2D<CopyBits,
+                   cute::gcd(8, get<0>(MMATile{})),
                    cute::gcd(512 / CopyBits, get<1>(MMATile{}))>,
         CopyOpR2G_
       >;
@@ -667,8 +667,8 @@ struct XeAuxLoad {
       // Block 2D copy path (explicit CopyOp or auto-deduced)
       using ActualCopyOpG2R = cute::conditional_t<
         cute::is_void_v<CopyOpG2R_>,
-        XE_LOAD_2D<CopyBits, 
-                   cute::gcd(8, get<0>(MMATile{})), 
+        XE_LOAD_2D<CopyBits,
+                   cute::gcd(8, get<0>(MMATile{})),
                    cute::gcd(512 / CopyBits, get<1>(MMATile{}))>,
         CopyOpG2R_
       >;

--- a/test/unit/cute/intel_xe/CMakeLists.txt
+++ b/test/unit/cute/intel_xe/CMakeLists.txt
@@ -45,6 +45,7 @@ cutlass_test_unit_add_executable(
   copy_subgroup_block.cpp
   copy_block.cpp
   copy_scatter.cpp
+  copy_d_selection.cpp
   mma.cpp
   tiled_mma.cpp
   xe_copy_2d_test.cpp

--- a/test/unit/cute/intel_xe/copy_d_selection.cpp
+++ b/test/unit/cute/intel_xe/copy_d_selection.cpp
@@ -1,0 +1,72 @@
+/***************************************************************************************************
+ * Copyright (C) 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+
+#include <cute/tensor.hpp>
+#include <cute/atom/copy_traits_xe_2d.hpp>
+#include <cute/arch/mma_xe.hpp>
+
+#include "cutlass_unit_test.h"
+
+using namespace cute;
+
+namespace {
+
+using DType = bfloat16_t;
+using DpasAtom = MMA_Atom<XE_DPAS_TT<8, float, DType>>;
+
+// Qwen3 small-K shape: WGTile <128,128,16>, SG <4,2>.  Each subgroup owns a
+// contiguous 64-column N run (128 / 2), which is two BF16 MMA N-atoms -> the D
+// store should be sized to a full 64B cache line (32 elements), not one atom (16).
+using SGLayout = Layout<Shape<_4, _2, _1>, Stride<_2, _1, _0>>;
+using TiledMMA = typename TiledMMAHelper<
+    DpasAtom,
+    Layout<Shape<_128, _128, _16>>,
+    SGLayout>::TiledMMA;
+
+// A tiling whose per-subgroup N run is only one atom wide (tile_n / sg_n = 16):
+// the store must stay single-atom (16), i.e. the width is derived, not forced.
+using NarrowSGLayout = Layout<Shape<_8, _2, _1>, Stride<_2, _1, _0>>;
+using NarrowTiledMMA = typename TiledMMAHelper<
+    DpasAtom,
+    Layout<Shape<_128, _32, _16>>,
+    NarrowSGLayout>::TiledMMA;
+
+using RowMajorD = Layout<Shape<_128, _128>, Stride<_128, _1>>;
+using ColMajorD = Layout<Shape<_128, _128>, Stride<_1, _128>>;
+using RowMajorNarrowD = Layout<Shape<_128, _32>, Stride<_32, _1>>;
+
+template <class Layout>
+auto make_d_tensor()
+{
+  return make_tensor(make_gmem_ptr(static_cast<DType*>(nullptr)), Layout{});
+}
+
+using RowMajorCopy = decltype(make_block_2d_copy_D(
+    TiledMMA{}, make_d_tensor<RowMajorD>()));
+using ColMajorCopy = decltype(make_block_2d_copy_D(
+    TiledMMA{}, make_d_tensor<ColMajorD>()));
+using NarrowRowMajorCopy = decltype(make_block_2d_copy_D(
+    NarrowTiledMMA{}, make_d_tensor<RowMajorNarrowD>()));
+
+// The store width is derived from the per-subgroup output tile's contiguous run, so
+// the Qwen small-K shape groups two BF16 MMA N-atoms into one full 64B cache line.
+static_assert(RowMajorCopy::CopyOp::AtomWidth == 32,
+              "row-major D with a two-atom subgroup N run should fill a full cache line");
+
+// The width follows whichever dimension is gmem-contiguous.  For column-major D the
+// contiguous direction is M, and the subgroup's 32-row M run still fills a cache line.
+static_assert(ColMajorCopy::CopyOp::AtomWidth == 32,
+              "column-major D fills a cache line along its contiguous (M) direction");
+
+// When the per-subgroup contiguous run is a single atom, the width degrades to one
+// atom on its own -- the wide store is a property of the derived tiling, never forced.
+static_assert(NarrowRowMajorCopy::CopyOp::AtomWidth == 16,
+              "a single-atom subgroup run must not be widened");
+
+} // namespace
+
+TEST(PVC_CuTe_Xe, automatic_d_copy_width_is_layout_derived) {
+  SUCCEED();
+}

--- a/test/unit/cute/intel_xe/copy_d_selection.cpp
+++ b/test/unit/cute/intel_xe/copy_d_selection.cpp
@@ -1,6 +1,32 @@
 /***************************************************************************************************
  * Copyright (C) 2026 Intel Corporation, All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
  **************************************************************************************************/
 
 #include <cute/tensor.hpp>


### PR DESCRIPTION
Derive the make_block_2d_copy_D width from the contiguous per-subgroup N run instead of a single MMA atom

Migrate 5 cute tutorials to the bridge pattern (partition_sg_fragment_S + reorder + copy) required by the wider store atom.

## Description
<!-- What does this PR do? -->

## Type
- [ ] Bug  - [ ] Feature  - [x] Performance  - [ ] Refactor

## Testing
- [ ] Tests pass  - [ ] Xe12  - [x] Xe20

## Performance
| Metric | Before | After |
|--------|--------|-------|
|        |        |       |

## References
Fixes #

## Checklist
- [ ] Copyright  - [ ] Co-pilot Review  - [ ] Deprecated APIs not used
