### PR TITLE
gemm: pass `this` by reference for kernel lambda captures

### DIFF
--- a/include/cutlass/gemm/collective/sm100_blockscaled_mma_array_warpspecialized.hpp
+++ b/include/cutlass/gemm/collective/sm100_blockscaled_mma_array_warpspecialized.hpp
@@ -711,7 +711,7 @@ struct CollectiveMma<
       layout_SFB = params.layout_SFB;
     }
     Tensor mSFA_mkl = observed_tma_load_sfa_->get_tma_tensor(shape(layout_SFA));
-    auto mSFB_nkl = [=](){
+    auto mSFB_nkl = [&](){
       if constexpr (IsCtaN192) {
         Tensor mSFB_tmp = observed_tma_load_sfb_->get_tma_tensor(shape(layout_SFB));
         auto x = stride<0,1>(mSFB_tmp);

--- a/include/cutlass/gemm/collective/sm100_blockscaled_mma_mixed_tma_cpasync_warpspecialized.hpp
+++ b/include/cutlass/gemm/collective/sm100_blockscaled_mma_mixed_tma_cpasync_warpspecialized.hpp
@@ -549,7 +549,7 @@ struct CollectiveMma<
 
     // Represent the full tensor of Scale factors
     Tensor mSFA_mkl = observed_tma_load_sfa_->get_tma_tensor(shape(layout_SFA_));
-    auto mSFB_nkl = [=](){
+    auto mSFB_nkl = [&](){
       if constexpr (IsCtaN192) {
         Tensor mSFB_tmp = observed_tma_load_sfb_->get_tma_tensor(shape(layout_SFB_));
         auto x = stride<0,1>(mSFB_tmp);

--- a/include/cutlass/gemm/collective/sm100_blockscaled_mma_warpspecialized.hpp
+++ b/include/cutlass/gemm/collective/sm100_blockscaled_mma_warpspecialized.hpp
@@ -712,7 +712,7 @@ struct CollectiveMma<
 
     // Represent the full tensor of Scale factors
     Tensor mSFA_mkl = observed_tma_load_sfa_->get_tma_tensor(shape(layout_SFA_));
-    auto mSFB_nkl = [=](){
+    auto mSFB_nkl = [&](){
       if constexpr (IsCtaN192) {
         Tensor mSFB_tmp = observed_tma_load_sfb_->get_tma_tensor(shape(layout_SFB_));
         auto x = stride<0,1>(mSFB_tmp);

--- a/include/cutlass/gemm/collective/sm100_blockscaled_sparse_mma_warpspecialized.hpp
+++ b/include/cutlass/gemm/collective/sm100_blockscaled_sparse_mma_warpspecialized.hpp
@@ -897,7 +897,7 @@ struct CollectiveMma<
 
     // Represent the full tensor of Scale factors
     Tensor mSFA_mkl = observed_tma_load_sfa_->get_tma_tensor(shape(layout_SFA_));
-    auto mSFB_nkl = [=](){
+    auto mSFB_nkl = [&](){
       if constexpr (IsCtaN192) {
         Tensor mSFB_tmp = observed_tma_load_sfb_->get_tma_tensor(shape(layout_SFB_));
         auto x = stride<0,1>(mSFB_tmp);

--- a/include/cutlass/gemm/collective/sm103_blockscaled_mma_array_warpspecialized.hpp
+++ b/include/cutlass/gemm/collective/sm103_blockscaled_mma_array_warpspecialized.hpp
@@ -805,7 +805,7 @@ struct CollectiveMma<
 
     // Represent the full tensor of Scale factors
     Tensor mSFA_mkl = observed_tma_load_sfa_->get_tma_tensor(shape(layout_SFA));
-    auto mSFB_nkl = [=](){
+    auto mSFB_nkl = [&](){
       if constexpr (IsCtaN192) {
         Tensor mSFB_tmp = observed_tma_load_sfb_->get_tma_tensor(shape(layout_SFB));
         auto x = stride<0,1>(mSFB_tmp);

--- a/include/cutlass/gemm/collective/sm103_blockscaled_mma_warpspecialized.hpp
+++ b/include/cutlass/gemm/collective/sm103_blockscaled_mma_warpspecialized.hpp
@@ -677,7 +677,7 @@ struct CollectiveMma<
 
     // Represent the full tensor of Scale factors
     Tensor mSFA_mkl = observed_tma_load_sfa_->get_tma_tensor(shape(params.layout_SFA));
-    auto mSFB_nkl = [=](){
+    auto mSFB_nkl = [&](){
       if constexpr (IsCtaN192) {
         Tensor mSFB_tmp = observed_tma_load_sfb_->get_tma_tensor(shape(params.layout_SFB));
         auto x = stride<0,1>(mSFB_tmp);

--- a/include/cutlass/gemm/collective/sm120_blockscaled_sparse_mma_tma.hpp
+++ b/include/cutlass/gemm/collective/sm120_blockscaled_sparse_mma_tma.hpp
@@ -701,7 +701,7 @@ struct CollectiveMma<
     Tensor mB_nkl = mainloop_params.tma_load_b.get_tma_tensor(make_shape(N,K,L));                            // (n,k,l)
     Tensor mE_mkl = mainloop_params.tma_load_e.get_tma_tensor(mainloop_params.layout_e.shape());             // (m,k,l)
     Tensor mSFA_mkl = mainloop_params.tma_load_sfa.get_tma_tensor(shape(mainloop_params.layout_SFA));
-    auto mSFB_nkl = [=](){
+    auto mSFB_nkl = [&](){
       if constexpr (IsCtaN64) {
         Tensor mSFB_tmp = mainloop_params.tma_load_sfb.get_tma_tensor(shape(mainloop_params.layout_SFB));
         auto x = stride<0,1>(mSFB_tmp);


### PR DESCRIPTION
## Description
C++20 has deprecated implicit capture by value for `this` with `[=](){`. An alternative fix is to explicitly include `this` in the capture list with `[=, this](){`. However, this emits a warning with C++17 and below.

These warnings currently cause `vllm-xpu-kernels` to fail building with `torch>=2.13`, `C++20` support mandated for kernels, and `-Werror` enabled.

## Type
- [x] Bug
- [ ] Feature
- [ ] Performance
- [ ] Refactor

## Testing
- [x] Tests pass
- [x] Xe12
- [ ] Xe20

## References
This issue is inherited from upstream. There is an outstanding PR on CUTLASS's repository that also fixes this issue (see https://github.com/NVIDIA/cutlass/issues/2997), however it is stale.

## Checklist
- [x] Copyright
- [ ] Co-pilot Review
- [ ] Deprecated APIs not used