### PR TITLE
ci: Remove duplicates and assign build jobs

### DIFF
--- a/.github/workflows/intel_test.yml
+++ b/.github/workflows/intel_test.yml
@@ -1,11 +1,7 @@
 name: "SYCL Intel Test"
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
-  merge_group:
     branches: [ "main" ]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/intel_test_gpp_host.yml
+++ b/.github/workflows/intel_test_gpp_host.yml
@@ -1,11 +1,7 @@
 name: "Intel G++ Host Compilation Test "
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
-  merge_group:
     branches: [ "main" ]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/intel_test_gpp_host_reusable.yml
+++ b/.github/workflows/intel_test_gpp_host_reusable.yml
@@ -50,8 +50,7 @@ jobs:
             echo "IGC_VERSION_MINOR=11" >> $GITHUB_ENV
           fi
 
-      - name: Calculate job allocation based on memory for BMG
-        if: matrix.gpu == 'BMG'
+      - name: Calculate job allocation based on memory 
         shell: bash
         run: |
           # Get total memory in KB and convert to GB
@@ -117,11 +116,7 @@ jobs:
             -DCMAKE_CXX_FLAGS="-Werror" \
             -DDPCPP_HOST_COMPILER=g++-13 \
             -DDPCPP_HOST_COMPILER_OPTIONS="-Werror"
-          if [ "${{ matrix.gpu }}" = "BMG" ]; then
-            cmake --build . -j ${{ env.BUILD_JOBS }}
-          else
-            cmake --build .
-          fi
+          cmake --build . -j ${{ env.BUILD_JOBS }}
 
       - name: Unit test
         shell: bash

--- a/.github/workflows/intel_test_reusable.yml
+++ b/.github/workflows/intel_test_reusable.yml
@@ -50,8 +50,7 @@ jobs:
             echo "IGC_VERSION_MINOR=11" >> $GITHUB_ENV
           fi
 
-      - name: Calculate job allocation based on memory for BMG
-        if: matrix.gpu == 'BMG'
+      - name: Calculate job allocation based on memory
         shell: bash
         run: |
           # Get total memory in KB and convert to GB
@@ -115,11 +114,7 @@ jobs:
             -DIGC_VERSION_MINOR=${{ env.IGC_VERSION_MINOR }} \
             -DCMAKE_CXX_FLAGS="-Werror" \
             -DCUTLASS_SYCL_RUNNING_CI=ON
-          if [ "${{ matrix.gpu }}" = "BMG" ]; then
-            cmake --build . -j ${{ env.BUILD_JOBS }}
-          else
-            cmake --build .
-          fi 
+          cmake --build . -j ${{ env.BUILD_JOBS }}
       
       - name: Unit test
         shell: bash


### PR DESCRIPTION
- Removed multiple CI runs to reduce time. 
- Added cmake parallel job assignment added to pvc as well since pr812 is failing.