### PR TITLE
FIX BMG GEMM Performance regression

### DIFF
--- a/examples/cute/tutorial/xe_gemm.cpp
+++ b/examples/cute/tutorial/xe_gemm.cpp
@@ -202,8 +202,7 @@ choose_tiled_mma(ATensor const& A, BTensor const& B, CTensor const&)
 
   constexpr bool use_1x_dpas_per_k = a_t                                  // Use one DPAS in k dimension for A^T case
                                   || (byte && b_n);                       //  pending compiler improvements (also int8 B^N).
-  constexpr bool use_4x8_sg = ((sizeof_bits_v<TB> < sizeof_bits_v<TA>)    // Use smaller B loads for expensive reorders.
-                                  && !(is_same_v<TB, cute::float_e5m2_t>))
+  constexpr bool use_4x8_sg = (sizeof_bits_v<TB> < sizeof_bits_v<TA>)     // Use smaller B loads for expensive reorders.
                            || (b_n && sizeof_bits_v<TB> < 8);
 
   using _K = conditional_t<use_1x_dpas_per_k,

--- a/include/cute/arch/copy_xe_2d.hpp
+++ b/include/cute/arch/copy_xe_2d.hpp
@@ -81,11 +81,19 @@ struct XE_LOAD_2D : XE_Copy_Op_2D_Base<Bits, Height, Width, Width/BlockWidth>
     // TODO: to workaround the GRF aligned visa issue, may have better way in the future
     constexpr auto grf_aligned_size = cute::max(64, Width * Height);
     auto &dv = *reinterpret_cast<storage_vector_t<T, grf_aligned_size * Bits / sg_size> *>(dst);
+#if defined(SYCL_INTEL_TARGET) && (SYCL_INTEL_TARGET == 35)
     asm (
       "lsc_load_block2d.ugm.ca.ca.uc (M1, 1)  %0:d%2.%3x%4x%5nn flat[%1+(0,0)]"
         : "=rw"(dv)
         : "rw.u"(payload), "P"(Bits), "P"(Width/BlockWidth), "P"(BlockWidth), "P"(Height)
     );
+#else
+    asm (
+      "lsc_load_block2d.ugm (M1, 1)  %0:d%2.%3x%4x%5nn flat[%1+(0,0)]"
+        : "=rw"(dv)
+        : "rw.u"(payload), "P"(Bits), "P"(Width/BlockWidth), "P"(BlockWidth), "P"(Height)
+    );
+#endif
 #else
     CUTE_INVALID_CONTROL_PATH("Cannot use Xe block 2D copy atom on non-Xe hardware");
 #endif
@@ -104,11 +112,19 @@ struct XE_LOAD_2D_VNNI : XE_Copy_Op_2D_Base<Bits, Height, Width, Width/BlockWidt
 #ifdef CUTE_ARCH_COPY_XE_ENABLED
     using namespace intel;
     auto &dv = *reinterpret_cast<storage_vector_t<T, Width * Height * Bits / sg_size>*>(dst);
+#if defined(SYCL_INTEL_TARGET) && (SYCL_INTEL_TARGET == 35)
     asm (
       "lsc_load_block2d.ugm.ca.ca.uc (M1, 1)  %0:d%2.%3x%4x%5nt flat[%1+(0,0)]"
         : "=rw"(dv)
         : "rw.u"(payload), "P"(Bits), "P"(Width/BlockWidth), "P"(BlockWidth), "P"(Height)
     );
+#else
+    asm (
+      "lsc_load_block2d.ugm (M1, 1)  %0:d%2.%3x%4x%5nt flat[%1+(0,0)]"
+        : "=rw"(dv)
+        : "rw.u"(payload), "P"(Bits), "P"(Width/BlockWidth), "P"(BlockWidth), "P"(Height)
+    );
+#endif
 #else
     CUTE_INVALID_CONTROL_PATH("Cannot use Xe block 2D copy atom on non-Xe hardware");
 #endif
@@ -135,11 +151,19 @@ struct XE_LOAD_2D_TRANSPOSE : XE_Copy_Op_2D_Base<Bits, Height, Width, 1, true>
 #ifdef CUTE_ARCH_COPY_XE_ENABLED
     using namespace intel;
     auto &dv = *reinterpret_cast<storage_vector_t<T, Width * Height * Bits / sg_size>*>(dst);
+#if defined(SYCL_INTEL_TARGET) && (SYCL_INTEL_TARGET == 35)
     asm (
       "lsc_load_block2d.ugm.ca.ca.uc (M1, 1)  %0:d%2.%3x%4tn flat[%1+(0,0)]"
         : "=rw"(dv)
         : "rw.u"(payload), "P"(Bits), "P"(Width), "P"(Height)
     );
+#else
+    asm (
+      "lsc_load_block2d.ugm (M1, 1)  %0:d%2.%3x%4tn flat[%1+(0,0)]"
+        : "=rw"(dv)
+        : "rw.u"(payload), "P"(Bits), "P"(Width), "P"(Height)
+    );
+#endif
 #else
     CUTE_INVALID_CONTROL_PATH("Cannot use Xe block 2D copy atom on non-Xe hardware");
 #endif

--- a/include/cute/atom/copy_traits_xe_2d.hpp
+++ b/include/cute/atom/copy_traits_xe_2d.hpp
@@ -875,8 +875,12 @@ block_2d_selector(CoordLayout const&, GlobalStride const&)
     //   (Rationale: we are already moving data, so layouts don't need to match)
     constexpr int y_stride = get_block_size<y_mode()>(slayout);
     constexpr int max_h = Store ? 8 : 32;
+#if defined(SYCL_INTEL_TARGET) && (SYCL_INTEL_TARGET == 35)
     constexpr int height = Store ? cute::gcd(resize ? get<y_mode()>(shape) : y_stride, max_h) :
                                    cute::gcd(get<y_mode()>(shape), max_h);
+#else
+    constexpr int height = cute::gcd(resize ? get<y_mode()>(shape) : y_stride, max_h);
+#endif
 
     if constexpr (Store)
       return XE_STORE_2D    <CopyBits, height, cwidth>{};


### PR DESCRIPTION
## Description

Fix BMG block2d loads by applying Xe3P-specific cache controls only when SYCL_INTEL_TARGET == 35.
Restore BMG-compatible block height selection for non-Xe3P targets.
Use the 4x8 subgroup layout for BF16 × e5m2 GEMM to address the performance regression.

## Expected Impact
Restores BMG GEMM correctness/performance behavior for block2d loads.
Improves BF16 × e5m2 GEMM performance in the CuTe tutorial path.
