### PR TITLE
Add LSE (log-sum-exp) output to FMHA forward kernel + sequence-parallel validation example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 cutlass_library.egg-info/
 cutlass_sycl.egg-info/
 /build*
+# Editor/build caches (e.g. clangd index)
+.cache/

--- a/applications/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
+++ b/applications/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
@@ -206,38 +206,26 @@ public:
     /* ---- Write LSE output if requested ---- */
     if (lse_ptr) {
       /* The softmax uses exp2 throughout. LSE = max + log2(sum).
-         After rA_sum inversion: log2(1/rA_sum) = log(1/rA_sum) * log2(e) */
+         After rA_sum inversion: log2(1/rA_sum) = log(1/rA_sum) * log2(e). */
       constexpr float kLog2e = 1.4426950408889634f;
-      constexpr int num_q_elems = sizeof(FragARow) / sizeof(ElementA);
-      constexpr int total_a_elems = sizeof(FragA) / sizeof(ElementA);
-      constexpr int tile_q_size = size<0>(TileShapeO{});
-      constexpr int elems_per_q = total_a_elems / num_q_elems;
-      static_assert(total_a_elems % num_q_elems == 0,
-                    "FragA elements must be divisible by FragARow elements");
-
-      /* Write LSE.  Each subgroup covers a portion of the Q output.
-         tile_q_size / SGPerWG gives Q-rows per subgroup (minimum 1).
-         The last tile may have fewer Q-rows; the q_global check handles it. */
-      constexpr int total_tile_sgs = decltype(SGPerWG{})::value;
-      constexpr int q_per_sg = tile_q_size > total_tile_sgs
-                               ? (tile_q_size + total_tile_sgs - 1) / total_tile_sgs
-                               : 1;
-      int sg_id = thr_id / intel::sg_size;
-      int q_offset = sg_id * q_per_sg;
-      int blk_q = static_cast<int>(cute::get<0>(blk_qv));
       int total_q_global = size<0>(O.shape());
       int64_t lse_base = (int64_t)idx_b * (int64_t)num_heads_q_param * (int64_t)total_q_global +
                           (int64_t)head_q * (int64_t)total_q_global;
+      /* The reduced O fragment (rA) is aligned with the per-thread partition of
+         the global-coordinate tensor (tOgO): tOgO(i) == (q, v) global coordinate
+         of rA(i) (the same tensor used by the O store).  Per-row max/sum are
+         fetched with broadcast<0>, exactly as the O store does.  Each (q,v)
+         element is owned by a single work-item, so writing only the v==0 element
+         of each row writes every Q row exactly once. */
       CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < q_per_sg; ++i) {
-        int q_global = blk_q * tile_q_size + q_offset + i;
-        if (q_global < total_q_global) {
-          /* Access tA_max/rA_sum using the position within this SG's range.
-             Use q_idx = i (since num_q_elems may differ from q_per_sg due to
-             VTiles folding, clamp to num_q_elems-1 if needed). */
-          int qi = i < num_q_elems ? i : num_q_elems - 1;
-          ElementA lse_val = tA_max(qi) + sycl::log(ElementA(1) / rA_sum(qi)) * kLog2e;
-          lse_ptr[lse_base + q_global] = static_cast<float>(lse_val);
+      for (int i = 0; i < rA.size(); ++i) {
+        if (get<1>(tOgO(i)) == 0) {
+          int q_global = get<0>(tOgO(i));
+          if (q_global < total_q_global) {
+            ElementA lse_val = broadcast<0>(tA_max, rA, i)
+                             + sycl::log(ElementA(1) / broadcast<0>(rA_sum, rA, i)) * kLog2e;
+            lse_ptr[lse_base + q_global] = static_cast<float>(lse_val);
+          }
         }
       }
     }

--- a/applications/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
+++ b/applications/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
@@ -103,9 +103,17 @@ public:
   using DefaultTiledCopyO = decltype(default_tiled_copy_O_helper());
   using TiledCopyO = conditional_t<is_void_v<TiledCopyO_>, DefaultTiledCopyO, TiledCopyO_>;
 
-  // Stateless design -- no arguments or parameters.
-  struct Arguments {};
-  struct Params {};
+  // LSE output configuration (optional, null = skip).
+  struct Arguments {
+    float* lse_ptr = nullptr;
+    int seq_len_qo = 0;
+    int num_heads_q = 0;
+  };
+  struct Params {
+    float* lse_ptr = nullptr;
+    int seq_len_qo = 0;
+    int num_heads_q = 0;
+  };
 
   // Shared memory storage
   // Note sum/max tiles are padded to 16 elements, due to limitations in CuTe block load infrastructure.
@@ -121,11 +129,14 @@ public:
 
 private:
   SharedStorage &shared;
+  float* lse_ptr = nullptr;
+  int num_heads_q_param = 0;
+  int seq_len_qo_param = 0;
 
 public:
   static constexpr
   Params to_underlying_arguments(Arguments const &args, void * /* workspace */) {
-    return {};
+    return {args.lse_ptr, args.seq_len_qo, args.num_heads_q};
   }
 
   CUTLASS_HOST_DEVICE static bool can_implement(Arguments const&) {
@@ -133,7 +144,11 @@ public:
   }
 
   CUTLASS_HOST_DEVICE
-  FMHAFwdEpilogue(Params const&, SharedStorage& shared_) : shared(shared_) {}
+  FMHAFwdEpilogue(Params const& params_, SharedStorage& shared_)
+    : shared(shared_),
+      lse_ptr(params_.lse_ptr),
+      num_heads_q_param(params_.num_heads_q),
+      seq_len_qo_param(params_.seq_len_qo) {}
 
   template <bool SumIsReduced = false, typename QVCoord, typename FragSPRow>
   CUTLASS_DEVICE
@@ -144,6 +159,8 @@ public:
              FragSPRow      & tA_sum,   // Softmax row-wise partial sum (per-lane, deferred hreduce)
              QVCoord          blk_qv,   // WG tile indices: (q,v)
              int              thr_id,   // Work-item ID
+             int              head_q,   // Query-head index (for LSE output)
+             int              idx_b,    // Batch index (for LSE output)
              float            v_scale = 1.0f) { // Per-tensor V dequant scale (fp8 path)
 
     using namespace cute;
@@ -185,6 +202,45 @@ public:
     for (int i = 0; i < rA.size(); i++)
       tOrO(i) = static_cast<ElementO>(rA(i) * broadcast<0>(rA_sum, rA, i));
     copy(copy_o, tOrO, tOgO);
+
+    /* ---- Write LSE output if requested ---- */
+    if (lse_ptr) {
+      /* The softmax uses exp2 throughout. LSE = max + log2(sum).
+         After rA_sum inversion: log2(1/rA_sum) = log(1/rA_sum) * log2(e) */
+      constexpr float kLog2e = 1.4426950408889634f;
+      constexpr int num_q_elems = sizeof(FragARow) / sizeof(ElementA);
+      constexpr int total_a_elems = sizeof(FragA) / sizeof(ElementA);
+      constexpr int tile_q_size = size<0>(TileShapeO{});
+      constexpr int elems_per_q = total_a_elems / num_q_elems;
+      static_assert(total_a_elems % num_q_elems == 0,
+                    "FragA elements must be divisible by FragARow elements");
+
+      /* Write LSE.  Each subgroup covers a portion of the Q output.
+         tile_q_size / SGPerWG gives Q-rows per subgroup (minimum 1).
+         The last tile may have fewer Q-rows; the q_global check handles it. */
+      constexpr int total_tile_sgs = decltype(SGPerWG{})::value;
+      constexpr int q_per_sg = tile_q_size > total_tile_sgs
+                               ? (tile_q_size + total_tile_sgs - 1) / total_tile_sgs
+                               : 1;
+      int sg_id = thr_id / intel::sg_size;
+      int q_offset = sg_id * q_per_sg;
+      int blk_q = static_cast<int>(cute::get<0>(blk_qv));
+      int total_q_global = size<0>(O.shape());
+      int64_t lse_base = (int64_t)idx_b * (int64_t)num_heads_q_param * (int64_t)total_q_global +
+                          (int64_t)head_q * (int64_t)total_q_global;
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < q_per_sg; ++i) {
+        int q_global = blk_q * tile_q_size + q_offset + i;
+        if (q_global < total_q_global) {
+          /* Access tA_max/rA_sum using the position within this SG's range.
+             Use q_idx = i (since num_q_elems may differ from q_per_sg due to
+             VTiles folding, clamp to num_q_elems-1 if needed). */
+          int qi = i < num_q_elems ? i : num_q_elems - 1;
+          ElementA lse_val = tA_max(qi) + sycl::log(ElementA(1) / rA_sum(qi)) * kLog2e;
+          lse_ptr[lse_base + q_global] = static_cast<float>(lse_val);
+        }
+      }
+    }
   }
 
   // Reduce k-blocks of A and A_sum across WG, if needed.

--- a/applications/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
+++ b/applications/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp
@@ -50,7 +50,9 @@ using namespace cute;
 template <class CollectiveMainloop, // Attention mainloop
           class TileShapeO_,        // Shape of output tile, may be larger than P*V GEMM
           class TensorO_,           // 2D slice of global output tensor
-          class TiledCopyO_ = void> // Optional TiledCopy for loading O
+          class TiledCopyO_ = void, // Optional TiledCopy for loading O
+          bool EnableLSE = false>   // Compile-time LSE output; keeps the non-LSE
+                                    // instantiation free of any LSE overhead
 class FMHAFwdEpilogue {
 
 public:
@@ -203,28 +205,31 @@ public:
       tOrO(i) = static_cast<ElementO>(rA(i) * broadcast<0>(rA_sum, rA, i));
     copy(copy_o, tOrO, tOgO);
 
-    /* ---- Write LSE output if requested ---- */
-    if (lse_ptr) {
-      /* The softmax uses exp2 throughout. LSE = max + log2(sum).
-         After rA_sum inversion: log2(1/rA_sum) = log(1/rA_sum) * log2(e). */
-      constexpr float kLog2e = 1.4426950408889634f;
-      int total_q_global = size<0>(O.shape());
-      int64_t lse_base = (int64_t)idx_b * (int64_t)num_heads_q_param * (int64_t)total_q_global +
-                          (int64_t)head_q * (int64_t)total_q_global;
-      /* The reduced O fragment (rA) is aligned with the per-thread partition of
-         the global-coordinate tensor (tOgO): tOgO(i) == (q, v) global coordinate
-         of rA(i) (the same tensor used by the O store).  Per-row max/sum are
-         fetched with broadcast<0>, exactly as the O store does.  Each (q,v)
-         element is owned by a single work-item, so writing only the v==0 element
-         of each row writes every Q row exactly once. */
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < rA.size(); ++i) {
-        if (get<1>(tOgO(i)) == 0) {
-          int q_global = get<0>(tOgO(i));
-          if (q_global < total_q_global) {
-            ElementA lse_val = broadcast<0>(tA_max, rA, i)
-                             + sycl::log(ElementA(1) / broadcast<0>(rA_sum, rA, i)) * kLog2e;
-            lse_ptr[lse_base + q_global] = static_cast<float>(lse_val);
+    /* ---- Write LSE output if requested (compile-time gated so that the
+       non-LSE instantiation carries zero overhead) ---- */
+    if constexpr (EnableLSE) {
+      if (lse_ptr) {
+        /* The softmax uses exp2 throughout. LSE = max + log2(sum).
+           After rA_sum inversion: log2(1/rA_sum) = log(1/rA_sum) * log2(e). */
+        constexpr float kLog2e = 1.4426950408889634f;
+        int total_q_global = size<0>(O.shape());
+        int64_t lse_base = (int64_t)idx_b * (int64_t)num_heads_q_param * (int64_t)total_q_global +
+                            (int64_t)head_q * (int64_t)total_q_global;
+        /* The reduced O fragment (rA) is aligned with the per-thread partition of
+           the global-coordinate tensor (tOgO): tOgO(i) == (q, v) global coordinate
+           of rA(i) (the same tensor used by the O store).  Per-row max/sum are
+           fetched with broadcast<0>, exactly as the O store does.  Each (q,v)
+           element is owned by a single work-item, so writing only the v==0 element
+           of each row writes every Q row exactly once. */
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < rA.size(); ++i) {
+          if (get<1>(tOgO(i)) == 0) {
+            int q_global = get<0>(tOgO(i));
+            if (q_global < total_q_global) {
+              ElementA lse_val = broadcast<0>(tA_max, rA, i)
+                               + sycl::log(ElementA(1) / broadcast<0>(rA_sum, rA, i)) * kLog2e;
+              lse_ptr[lse_base + q_global] = static_cast<float>(lse_val);
+            }
           }
         }
       }

--- a/applications/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
+++ b/applications/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp
@@ -146,6 +146,7 @@ public:
     StrideK dK_cache{};
     const ElementV *V_cache;
     StrideV dV_cache{};
+    float *Lse = nullptr;  // LSE output buffer (null = skip)
   };
   using KernelParams = KernelArguments;
 
@@ -169,9 +170,16 @@ public:
   //
 
   static Params to_underlying_arguments(Arguments const &args, void *workspace) {
+    // Forward LSE info to epilogue if requested
+    auto epi_args = args.epilogue;
+    if (args.kernel.Lse) {
+      epi_args.lse_ptr = args.kernel.Lse;
+      epi_args.seq_len_qo = args.kernel.shape.seq_len_qo;
+      epi_args.num_heads_q = args.kernel.shape.num_heads_q;
+    }
     return {args.kernel,
             CollectiveMainloop::to_underlying_arguments(args.mainloop, workspace),
-            CollectiveEpilogue::to_underlying_arguments(args.epilogue, workspace),
+            CollectiveEpilogue::to_underlying_arguments(epi_args, workspace),
             TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{})};
   }
 
@@ -390,7 +398,7 @@ public:
       CollectiveEpilogue epilogue{params.epilogue, shared_storage.epilogue};
       epilogue(O(_,_,head_q,l_coord),
                tArA, tA_max, tA_sum,
-               blk_qv, thr_id, p.scale_v);
+               blk_qv, thr_id, head_q, idx_b, p.scale_v);
     }
   }
 };
@@ -485,6 +493,7 @@ public:
     StrideK dK_cache{};
     const ElementV *V_cache = nullptr;
     StrideV dV_cache{};
+    float *Lse = nullptr;  // LSE output buffer (null = skip)
   };
   using KernelParams = KernelArguments;
 
@@ -518,9 +527,16 @@ public:
     int max_parts = compute_max_num_partitions(args.hw_info.sm_count, num_batch_heads);
     int32_t *atomic_reduce_cnt_ptr = reinterpret_cast<int32_t *>(workspace);
     ElementA *partial_results_ptr = reinterpret_cast<ElementA *>(atomic_reduce_cnt_ptr + num_batch_heads);
+    // Forward LSE info to epilogue if requested
+    auto epi_args = args.epilogue;
+    if (args.kernel.Lse) {
+      epi_args.lse_ptr = args.kernel.Lse;
+      epi_args.seq_len_qo = args.kernel.shape.seq_len_qo;
+      epi_args.num_heads_q = args.kernel.shape.num_heads_q;
+    }
     return {args.kernel,
             CollectiveMainloop::to_underlying_arguments(args.mainloop, workspace),
-            CollectiveEpilogue::to_underlying_arguments(args.epilogue, workspace),
+            CollectiveEpilogue::to_underlying_arguments(epi_args, workspace),
             TileScheduler::to_underlying_arguments(args.kernel.shape, args.hw_info, TileShapeO{}),
             partial_results_ptr, atomic_reduce_cnt_ptr, max_parts
           };
@@ -840,7 +856,7 @@ public:
         CollectiveEpilogue epilogue{params.epilogue, shared_storage.epilogue};
         epilogue.template operator()<true>(O(_,_,head_q,idx_b),
                 tArA, tA_max, tA_sum,
-                blk_qv, thr_id);
+                blk_qv, thr_id, head_q, idx_b);
       }
     }
   }

--- a/examples/06_bmg_flash_attention/06_xe_fmha_fwd_lse.cpp
+++ b/examples/06_bmg_flash_attention/06_xe_fmha_fwd_lse.cpp
@@ -1,0 +1,160 @@
+/***************************************************************************************************
+ * Copyright (C) 2025 - 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+/*! \file
+    \brief Flash Attention V2 Prefill with LSE output & Sequence-Parallel combine
+           for Intel BMG
+
+    This example exercises the LSE output feature of the FMHA forward kernel
+    (float *Lse in the kernel arguments, written by FMHAFwdEpilogue). It
+    performs a sequence-parallel (SP) validation:
+
+      * The full KV sequence is split into `--seq_chunk_len`-sized chunks.
+      * For every chunk the kernel is launched with seq_len_kv = chunk length,
+        producing a partial output O_c and a partial log-sum-exp LSE_c.
+      * The partials are combined on the host using only the LSE values:
+            M   = max_c  LSE_c
+            w_c = exp(LSE_c - M)
+            O   = sum_c (w_c * O_c) / sum_c w_c
+      * The combined output is compared against a full-sequence reference, the
+        kernel LSE is compared against a host log-sum-exp reference, and the
+        performance of the single full launch vs the chunked SP launches is
+        reported.
+
+    Build & run (from your build dir):
+      $ ninja 06_xe_fmha_fwd_lse_bfloat16_t_hdim128
+      $ ./examples/sycl/06_bmg_flash_attention/06_xe_fmha_fwd_lse_bfloat16_t_hdim128 \
+            --seq_len_qo=512 --seq_len_kv=512 --seq_chunk_len=128
+
+    Call with `--help` for information about available options.
+*/
+
+#include "xe_fmha_fwd_runner.hpp"
+
+int main(int argc, const char **argv) {
+  //
+  // Parse options
+  //
+
+  Options options;
+
+  options.parse(argc, argv);
+
+  if (options.help) {
+    options.print_usage(std::cout) << std::endl;
+    return 0;
+  }
+
+  if (options.error) {
+    std::cerr << "Aborting execution." << std::endl;
+    return -1;
+  }
+
+#ifdef IS_FLOAT_E5M2
+#error "LSE / sequence-parallel example currently only supports bfloat16 inputs."
+#elif defined(IS_FLOAT_E4M3)
+#error "LSE / sequence-parallel example currently only supports bfloat16 inputs."
+#elif defined(IS_FLOAT_E2M1)
+#error "LSE / sequence-parallel example currently only supports bfloat16 inputs."
+#else
+  using ElementQ = bfloat16_t;
+  using ElementK = bfloat16_t;
+  using ElementV = bfloat16_t;
+#endif
+
+  // Sequence-parallel LSE example: PREFILL only, no causal / varlen / cached KV.
+#ifndef PREFILL
+#error "The LSE example must be compiled with PREFILL defined."
+#endif
+
+  if (options.is_causal) {
+    std::cerr << "Error: Sequence-parallel LSE example does not support --is_causal yet." << std::endl;
+    return -1;
+  }
+  if (options.varlen) {
+    std::cerr << "Error: Sequence-parallel LSE example does not support --varlen yet." << std::endl;
+    return -1;
+  }
+  if (options.seq_len_kv_cache > 0 || options.use_paged_kv) {
+    std::cerr << "Error: Sequence-parallel LSE example does not support cached/paged KV." << std::endl;
+    return -1;
+  }
+
+ // Define the work-group tile shape depending on the head-size of the second matmul
+#if HEAD_DIM == 16
+  /* Tiny config for testing */
+  using ShapeQK = Shape<_16, _16, _32>;       // (q,k,d)
+  using ShapePV = Shape<_16, _32, _16>;       // (q,v,k)
+  using ShapeOut = Shape<_16, _16>;           // (q,v)
+  using SubgroupLayoutQK = Layout<Shape<_1, _1, _1>>;
+
+#elif HEAD_DIM == 64
+  using ShapeQK = Shape<_128, _64, _32>;
+  using ShapePV = Shape<_128, _32, _64>;
+  using ShapeOut = Shape<_128, _64>;
+  using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+
+#elif HEAD_DIM == 96
+  using ShapeQK = Shape<_128, _64, _32>;
+  using ShapePV = Shape<_128, _32, _64>;
+  using ShapeOut = Shape<_128, _96>;
+  using SubgroupLayoutQK = Layout<Shape<_8, _1, _1>>;
+
+#elif HEAD_DIM == 128
+#if !(defined(SYCL_INTEL_TARGET) && (SYCL_INTEL_TARGET == 35))
+  using ShapeQK = Shape<_256, _32, _32>;
+  using ShapePV = Shape<_256, _32, _32>;
+  using ShapeOut = Shape<_256, _128>;
+  using SubgroupLayoutQK = Layout<Shape<_16, _1, _1>>;
+#else
+  using ShapeQK = Shape<_512, _64, _64>;
+  using ShapePV = Shape<_512, _64, _64>;
+  using ShapeOut = Shape<_512, _128>;
+  using SubgroupLayoutQK = Layout<Shape<_32, _1, _1>>;
+#endif
+#elif HEAD_DIM == 192
+  using ShapeQK = Shape<_256, _64, _32>;
+  using ShapePV = Shape<_256, _32, _64>;
+  using ShapeOut = Shape<_256, _192>;
+  using SubgroupLayoutQK = Layout<Shape<_16, _1, _1>>;
+
+#else
+#error "Unsupported HEAD_DIM"
+#endif
+
+  constexpr int PipelineStages = 2;
+
+  using Scheduler = cutlass::fmha::kernel::XeFHMAIndividualTileScheduler<>;
+
+  // Sequence-parallel LSE path: non-causal, non-varlen, no cache, no paged KV.
+  using FMHANonCausal = FMHAConfig<false, false, ShapeQK, ShapePV, ShapeOut, SubgroupLayoutQK, void, PipelineStages, false, ElementQ, ElementK, ElementV>;
+
+  return FMHANonCausal::template run_lse<false, false, false, Scheduler>(options);
+}

--- a/examples/06_bmg_flash_attention/CMakeLists.txt
+++ b/examples/06_bmg_flash_attention/CMakeLists.txt
@@ -64,6 +64,9 @@ foreach(HEAD_DIM 64 96 128 192)
       set(TEST_CACHED_KV_PREFILL "--seq_len_kv_cache=64")
       set(TEST_CACHED_KV_DECODE "--seq_len_kv_cache=64")
     endif()
+
+    # LSE / sequence-parallel prefill test: split KV into 128-token chunks.
+    set(TEST_LSE_PREFILL ${TEST_NO_PAGED_PREFILL} "--seq_chunk_len=128")
  
     if(INPUT_TYPE STREQUAL "bfloat16_t")
       set(INPUT_MACRO "IS_BFLOAT16")
@@ -142,6 +145,17 @@ foreach(HEAD_DIM 64 96 128 192)
         TEST_CACHED_KV_DECODE
       )
       target_compile_definitions(06_xe_fmha_fwd_decode_cached_kv_${INPUT_TYPE}_hdim${HEAD_DIM} PRIVATE HEAD_DIM=${HEAD_DIM} DECODE SHOW_DIFF=1 INPUT_TYPE=${INPUT_TYPE} ${INPUT_MACRO})
+    endif()
+
+    # --- LSE output / sequence-parallel target (bfloat16 only) ---
+    if (INPUT_TYPE STREQUAL "bfloat16_t")
+      cutlass_example_add_executable(
+        06_xe_fmha_fwd_lse_${INPUT_TYPE}_hdim${HEAD_DIM}
+        06_xe_fmha_fwd_lse.cpp
+        TEST_COMMAND_OPTIONS
+        TEST_LSE_PREFILL
+      )
+      target_compile_definitions(06_xe_fmha_fwd_lse_${INPUT_TYPE}_hdim${HEAD_DIM} PRIVATE HEAD_DIM=${HEAD_DIM} PREFILL SHOW_DIFF=1 INPUT_TYPE=${INPUT_TYPE} ${INPUT_MACRO})
     endif()
   endforeach()
 

--- a/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
+++ b/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
@@ -63,12 +63,12 @@ struct Options {
   bool use_paged_kv = false;
   std::string scheduler;
 
-  int batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache, page_size, head_size_qk, head_size_vo, iterations, warmup, verify;
+  int batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache, page_size, head_size_qk, head_size_vo, iterations, warmup, verify, seq_chunk_len;
   float softmax_scale;
 
   Options()
       : help(false), error(false), is_causal(false), varlen(false), use_paged_kv(false), batch(32), num_heads_q(16), num_heads_kv(16), seq_len_qo(512), head_size_qk(128),
-        seq_len_kv(512), seq_len_kv_cache(0), page_size(128), head_size_vo(128), iterations(100), warmup(100), softmax_scale(1.f), verify(1), scheduler("Individual") {}
+        seq_len_kv(512), seq_len_kv_cache(0), page_size(128), head_size_vo(128), iterations(100), warmup(100), softmax_scale(1.f), verify(1), scheduler("Individual"), seq_chunk_len(0) {}
 
   // Parses the command line
   void parse(int argc, char const **args) {
@@ -111,6 +111,7 @@ struct Options {
     cmd.get_cmd_line_argument("iterations", iterations, 100);
     cmd.get_cmd_line_argument("warmup", warmup, 1);
     cmd.get_cmd_line_argument("verify", verify, 1);
+    cmd.get_cmd_line_argument("seq_chunk_len", seq_chunk_len, 0);
 
     if (cmd.check_cmd_line_flag("use_paged_kv")) {
         use_paged_kv = true;
@@ -150,7 +151,9 @@ struct Options {
         << "  --head_size_vo=<int>        Sets the Attention Head dimension of the 2nd Matrix Multiplication in Multi-Head Self Attention module\n"
         << "  --iterations=<int>          Iterations\n"
         << "  --warmup=<int>              Warmup iterations before timing\n"
-        << "  --verify=<int>              Specify whether to verify.\n\n";
+        << "  --verify=<int>              Specify whether to verify.\n"
+        << "  --seq_chunk_len=<int>       KV chunk length for sequence-parallel (LSE) runs.\n"
+        << "                              <=0 means a single full chunk.\n\n";
     return out;
   }
 };
@@ -1128,6 +1131,340 @@ template <class FMHAKernel, bool isVarLen = false> struct ExampleRunner {
   }
 };
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Sequence-Parallel (SP) runner built on top of the new LSE output feature.
+//
+// The KV sequence is split into `sp_chunks` contiguous chunks. For each chunk we
+// launch the FMHA kernel with seq_len_kv = chunk length, pointing K/V at the
+// chunk slice of the full buffers (keeping the full-tensor strides, since the
+// buffers are flat [B, H, S, D] contiguous) and writing a partial output O_c
+// plus its log-sum-exp LSE_c. The partials are then combined on the host with
+// the standard sequence-parallel reduction, which only needs the LSE values:
+//
+//     M    = max_c  LSE_c
+//     w_c  = exp(LSE_c - M)
+//     O    = sum_c (w_c * O_c) / sum_c w_c
+//
+// The combined output is written into block_O and validated against the full
+// reference using ExampleRunner::verify(). The kernel LSE from a single full
+// run is additionally compared against a host log-sum-exp reference, and the
+// performance of the full vs the chunked (SP) execution is reported.
+//
+// Current restrictions: non-causal, non-varlen, no cached/paged KV, bf16.
+///////////////////////////////////////////////////////////////////////////////////////////////////
+template <class FMHAKernel, bool isVarLen = false>
+struct SequenceParallelRunner : public ExampleRunner<FMHAKernel, isVarLen> {
+  using Base = ExampleRunner<FMHAKernel, isVarLen>;
+  using ProblemShapeType = typename Base::ProblemShapeType;
+  using ElementQ = typename FMHAKernel::ElementQ;
+  using ElementK = typename FMHAKernel::ElementK;
+  using ElementV = typename FMHAKernel::ElementV;
+  using ElementO = typename FMHAKernel::ElementO;
+
+  // Buffers for sequence-parallel partial results
+  cutlass::DeviceAllocation<ElementO> partial_O;    // [sp_chunks][B][H][S][V]
+  cutlass::DeviceAllocation<float>    partial_lse;  // [sp_chunks][B][H][S]
+  cutlass::DeviceAllocation<ElementO> O_full;       // single full-run output
+  cutlass::DeviceAllocation<float>    lse_full;     // single full-run LSE
+
+  // Build kernel arguments for a (possibly chunked) KV problem. K/V point into
+  // the chunk slice, but the strides are the FULL-tensor strides (the buffers
+  // are flat contiguous [B, H, S, D]). This mirrors the varlen stride handling.
+  typename FMHAKernel::Arguments
+  make_arguments(const ProblemShapeType &shape,
+                 ElementO *O_ptr, ElementK *K_ptr, ElementV *V_ptr,
+                 float *lse_ptr,
+                 const Options &options,
+                 const cutlass::KernelHardwareInfo &hw_info) {
+    typename FMHAKernel::Arguments args{
+      {
+        shape,
+        this->block_Q.get(), this->stride_Q,
+        K_ptr, this->stride_K,
+        V_ptr, this->stride_V,
+        O_ptr, this->stride_O,
+        nullptr, typename FMHAKernel::StrideScaleQ{},
+        nullptr, typename FMHAKernel::StrideScaleK{},
+        nullptr, typename FMHAKernel::StrideScaleV{},
+        /*scale_k=*/1.f, /*scale_v=*/1.f, /*scale_q=*/1.f,
+        GROUP_SIZE,
+        nullptr, typename FMHAKernel::StrideK{},       // no cached KV in SP runs
+        nullptr, typename FMHAKernel::StrideV{},
+        lse_ptr
+      },
+      { options.softmax_scale, nullptr, 0, nullptr },   // no paged KV
+      {},                                               // no epilogue args
+      hw_info
+    };
+    return args;
+  }
+
+  // Host reference: LSE = log2( sum_s exp(softmax_scale * (Q_q . K_s)) ) for
+  // each (b, h, q). The kernel softmax is exp2-based, so its LSE is in log
+  // base 2; we match that here (kLog2e = log2(e)).
+  void compute_reference_lse(const ProblemShapeType &shape, float softmax_scale,
+                             std::vector<float> &lse_ref) {
+    auto batch = shape.batch;
+    auto num_heads_q = shape.num_heads_q;
+    auto num_heads_kv = shape.num_heads_kv;
+    auto seq_len_qo = shape.seq_len_qo;
+    auto seq_len_kv = shape.seq_len_kv;
+    auto head_size_qk = shape.head_size_qk;
+
+    std::vector<ElementQ> q_host(this->block_Q.size());
+    std::vector<ElementK> k_host(this->block_K.size());
+    compat::memcpy<ElementQ>(q_host.data(), this->block_Q.get(), q_host.size());
+    compat::memcpy<ElementK>(k_host.data(), this->block_K.get(), k_host.size());
+    compat::wait();
+
+    constexpr float kLog2e = 1.4426950408889634f;
+    int head_group = num_heads_q / num_heads_kv;
+    std::size_t rows = (std::size_t)batch * num_heads_q * seq_len_qo;
+    lse_ref.assign(rows, 0.f);
+    std::vector<float> s(seq_len_kv);
+    for (int b = 0; b < batch; ++b) {
+      for (int h = 0; h < num_heads_q; ++h) {
+        int h_kv = h / head_group;
+        std::size_t q_base = ((std::size_t)b * num_heads_q + h) * seq_len_qo * head_size_qk;
+        std::size_t k_base = ((std::size_t)b * num_heads_kv + h_kv) * seq_len_kv * head_size_qk;
+        for (int q = 0; q < seq_len_qo; ++q) {
+          float maxv = -INFINITY;
+          for (int kv = 0; kv < seq_len_kv; ++kv) {
+            float dot = 0.f;
+            for (int d = 0; d < head_size_qk; ++d) {
+              dot += (float)q_host[q_base + q * head_size_qk + d]
+                   * (float)k_host[k_base + kv * head_size_qk + d];
+            }
+            s[kv] = softmax_scale * dot;
+            maxv = std::max(maxv, s[kv]);
+          }
+          float sum_exp = 0.f;
+          for (int kv = 0; kv < seq_len_kv; ++kv) sum_exp += expf(s[kv] - maxv);
+          std::size_t idx = ((std::size_t)b * num_heads_q + h) * seq_len_qo + q;
+          lse_ref[idx] = (maxv + logf(sum_exp)) * kLog2e;
+        }
+      }
+    }
+  }
+
+  // Combine partial (O_c, LSE_c) over the KV chunks into a single output.
+  //
+  // The kernel LSE is the log-sum-exp in BASE 2 (LSE_c = log2(Z_c), where
+  // Z_c = sum_k exp(s_k) over the chunk).  The exact combine is
+  //   w_c = 2^(LSE_c - M) = exp2f(LSE_c - M),   M = max_c LSE_c,
+  //   O   = sum_c (w_c * O_c) / sum_c w_c.
+  // (The common factor 2^-M cancels between numerator and denominator.)
+  void combine_partials(int sp_chunks, int batch, int num_heads_q,
+                        int seq_len_qo, int head_size_vo,
+                        const std::vector<float> &lse_host,
+                        const std::vector<ElementO> &partial_O_host,
+                        std::vector<ElementO> &combined) {
+    std::size_t rows = (std::size_t)batch * num_heads_q * seq_len_qo;
+    combined.assign(rows * head_size_vo, ElementO(0));
+    std::vector<float> acc(head_size_vo);
+    for (std::size_t r = 0; r < rows; ++r) {
+      float M = -INFINITY;
+      for (int c = 0; c < sp_chunks; ++c)
+        M = std::max(M, lse_host[(std::size_t)c * rows + r]);
+      float sum_w = 0.f;
+      std::fill(acc.begin(), acc.end(), 0.f);
+      for (int c = 0; c < sp_chunks; ++c) {
+        float w = exp2f(lse_host[(std::size_t)c * rows + r] - M);
+        sum_w += w;
+        const ElementO *Oc = &partial_O_host[(std::size_t)c * rows * head_size_vo + r * head_size_vo];
+        for (int d = 0; d < head_size_vo; ++d) acc[d] += w * (float)Oc[d];
+      }
+      for (int d = 0; d < head_size_vo; ++d)
+        combined[r * head_size_vo + d] = (ElementO)(acc[d] / sum_w);
+    }
+  }
+
+  cutlass::Status run_sp(const Options &options, const cutlass::KernelHardwareInfo &hw_info) {
+
+    if (options.is_causal) {
+      std::cerr << "Error: Sequence-parallel LSE example does not support Causal mask yet." << std::endl;
+      return cutlass::Status::kErrorInvalidProblem;
+    }
+    if constexpr (isVarLen) {
+      std::cerr << "Error: Sequence-parallel LSE example does not support varlen yet." << std::endl;
+      return cutlass::Status::kErrorInvalidProblem;
+    }
+
+    ProblemShapeType shape = this->initialize(options);
+
+    int batch = shape.batch;
+    int num_heads_q = shape.num_heads_q;
+    int seq_len_qo = shape.seq_len_qo;
+    int seq_len_kv = shape.seq_len_kv;
+    int head_size_qk = shape.head_size_qk;
+    int head_size_vo = shape.head_size_vo;
+
+    // Sequence-parallel decomposition of the KV dimension.
+    int chunk_len = options.seq_chunk_len;
+    if (chunk_len <= 0) chunk_len = seq_len_kv;
+    chunk_len = std::min(chunk_len, seq_len_kv);
+    int sp_chunks = cute::ceil_div(seq_len_kv, chunk_len);
+
+    std::size_t rows = (std::size_t)batch * num_heads_q * seq_len_qo;
+    partial_O.reset(sp_chunks * rows * head_size_vo);
+    partial_lse.reset(sp_chunks * rows);
+    O_full.reset(rows * head_size_vo);
+    lse_full.reset(rows);
+
+    // Chunk K/V pointers into the full contiguous [B,H,S,D] buffers.
+    std::vector<ElementK*> k_chunk_ptr(sp_chunks);
+    std::vector<ElementV*> v_chunk_ptr(sp_chunks);
+    std::vector<int> chunk_kv_len(sp_chunks);
+    for (int c = 0; c < sp_chunks; ++c) {
+      int kv_start = c * chunk_len;
+      chunk_kv_len[c] = std::min(chunk_len, seq_len_kv - kv_start);
+      k_chunk_ptr[c] = this->block_K.get() + (std::size_t)kv_start * head_size_qk;
+      v_chunk_ptr[c] = this->block_V.get() + (std::size_t)kv_start * head_size_vo;
+    }
+
+    // Full-run (single chunk) and per-chunk shapes.
+    std::vector<ProblemShapeType> chunk_shapes(sp_chunks);
+    for (int c = 0; c < sp_chunks; ++c) {
+      chunk_shapes[c] = shape;
+      chunk_shapes[c].seq_len_kv = chunk_kv_len[c];
+      chunk_shapes[c].seq_len_kv_cache = 0;
+    }
+
+    typename FMHAKernel::Arguments full_args =
+        make_arguments(shape, O_full.get(), this->block_K.get(), this->block_V.get(),
+                       lse_full.get(), options, hw_info);
+
+    // FMHAKernel::Arguments is not copy-assignable (its mainloop Arguments holds
+    // a const member), so build the per-chunk args via copy construction.
+    std::vector<typename FMHAKernel::Arguments> chunk_args;
+    chunk_args.reserve(sp_chunks);
+    for (int c = 0; c < sp_chunks; ++c) {
+      chunk_args.push_back(make_arguments(chunk_shapes[c],
+                                          partial_O.get() + (std::size_t)c * rows * head_size_vo,
+                                          k_chunk_ptr[c], v_chunk_ptr[c],
+                                          partial_lse.get() + (std::size_t)c * rows,
+                                          options, hw_info));
+    }
+
+    if (!FMHAKernel::can_implement(full_args)) {
+      std::cout << "Invalid Problem Size: " << options.batch << 'x' << options.num_heads_q << 'x' <<
+        options.seq_len_qo << 'x' << options.seq_len_kv << 'x' << options.head_size_qk << 'x' << options.head_size_vo << std::endl;
+      return cutlass::Status::kErrorInvalidProblem;
+    }
+
+    std::size_t workspace_size = FMHAKernel::get_workspace_size(full_args);
+    cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+    CUTLASS_CHECK(FMHAKernel::initialize_workspace(full_args, workspace.get()));
+
+    auto launch = [&](const typename FMHAKernel::Arguments &args) {
+      auto params = FMHAKernel::to_underlying_arguments(args, workspace.get());
+      Base::run(params);
+    };
+
+    // Warmup
+    for (int i = 0; i < options.warmup; ++i) {
+      launch(full_args);
+      for (int c = 0; c < sp_chunks; ++c) launch(chunk_args[c]);
+    }
+    compat::wait();
+
+    // Performance: full single-kernel run vs sequence-parallel (all chunks).
+    // Measured in two alternating orders (full-then-sp, sp-then-full) and
+    // averaged, to cancel GPU DVFS/ordering bias between the two timings.
+    double ms_full = 0.0, ms_sp = 0.0;
+    if (options.iterations > 0) {
+      auto time_full = [&]() -> double {
+        GPU_Clock t;
+        t.start();
+        for (int i = 0; i < options.iterations; ++i) launch(full_args);
+        compat::wait();
+        return t.seconds() / options.iterations * 1000.0;
+      };
+      auto time_sp = [&]() -> double {
+        GPU_Clock t;
+        t.start();
+        for (int i = 0; i < options.iterations; ++i)
+          for (int c = 0; c < sp_chunks; ++c) launch(chunk_args[c]);
+        compat::wait();
+        return t.seconds() / options.iterations * 1000.0;
+      };
+      // order A: full first, then sp
+      ms_full += time_full();
+      ms_sp   += time_sp();
+      // order B: sp first, then full
+      ms_sp   += time_sp();
+      ms_full += time_full();
+      ms_full *= 0.5;
+      ms_sp   *= 0.5;
+    }
+
+    // Collect results (one execution per launch for validation)
+    launch(full_args);
+    for (int c = 0; c < sp_chunks; ++c) launch(chunk_args[c]);
+    compat::wait();
+
+    std::vector<ElementO> O_full_host(O_full.size());
+    std::vector<float>    lse_full_host(lse_full.size());
+    std::vector<ElementO> partial_O_host(partial_O.size());
+    std::vector<float>    partial_lse_host(partial_lse.size());
+    compat::memcpy<ElementO>(O_full_host.data(), O_full.get(), O_full.size());
+    compat::memcpy<float>(lse_full_host.data(), lse_full.get(), lse_full.size());
+    compat::memcpy<ElementO>(partial_O_host.data(), partial_O.get(), partial_O.size());
+    compat::memcpy<float>(partial_lse_host.data(), partial_lse.get(), partial_lse.size());
+    compat::wait();
+
+    bool full_passed = true, lse_passed = true, sp_passed = true;
+    if (options.verify != 0) {
+      // (1) Single full-kernel output vs reference
+      compat::memcpy<ElementO>(this->block_O.get(), O_full_host.data(), O_full_host.size());
+      compat::wait();
+      full_passed = this->verify(shape, /*is_causal=*/false);
+      std::cout << "Full kernel (LSE) output vs reference        : " << (full_passed ? "Passed" : "Failed") << std::endl;
+
+      // (2) Kernel LSE vs host log-sum-exp reference
+      std::vector<float> lse_ref;
+      compute_reference_lse(shape, options.softmax_scale, lse_ref);
+      float max_lse_err = 0.f;
+      for (std::size_t i = 0; i < lse_ref.size(); ++i)
+        max_lse_err = std::max(max_lse_err, std::fabs(lse_full_host[i] - lse_ref[i]));
+      lse_passed = (max_lse_err < 0.1f);
+      std::cout << "LSE output vs host log-sum-exp reference     : " << (lse_passed ? "Passed" : "Failed")
+                << "  (max abs err = " << max_lse_err << ")" << std::endl;
+
+      // (3) Sequence-parallel combined output vs reference
+      std::vector<ElementO> combined(rows * head_size_vo);
+      combine_partials(sp_chunks, batch, num_heads_q, seq_len_qo, head_size_vo,
+                       partial_lse_host, partial_O_host, combined);
+      compat::memcpy<ElementO>(this->block_O.get(), combined.data(), combined.size());
+      compat::wait();
+      sp_passed = this->verify(shape, /*is_causal=*/false);
+      std::cout << "Sequence-parallel (" << sp_chunks << " chunks) combined vs reference: "
+                << (sp_passed ? "Passed" : "Failed") << std::endl;
+    } else {
+      std::cout << "Disposition is skipped." << std::endl;
+    }
+
+    // Performance report
+    if (options.iterations > 0) {
+      double effective_seq_len_kv = (double)seq_len_kv;
+      double flops_qk = 2.0 * num_heads_q * (double)batch * seq_len_qo * effective_seq_len_kv * head_size_qk;
+      double flops_pv = 2.0 * num_heads_q * (double)batch * seq_len_qo * effective_seq_len_kv * head_size_vo;
+      double tflops_full = ((flops_qk + flops_pv) * 1e-12) / (ms_full / 1000.0);
+      double tflops_sp   = ((flops_qk + flops_pv) * 1e-12) / (ms_sp   / 1000.0);
+      std::cout << "Batch: " << batch << "\tNumHeads_q: " << num_heads_q << "\tNumHeads_kv: " << shape.num_heads_kv
+                << "\tSeq Length QO: " << seq_len_qo << "\tSeq Length KV: " << seq_len_kv
+                << "\tHead Size QK: " << head_size_qk << "\tHead Size VO: " << head_size_vo
+                << "\tSP Chunks: " << sp_chunks << " (chunk len " << chunk_len << ")" << std::endl;
+      printf("Performance Full:   %6.4f ms,  %4.3f TFlop/s\n", ms_full, tflops_full);
+      printf("Performance SP-%-2d:  %6.4f ms,  %4.3f TFlop/s\n", sp_chunks, ms_sp, tflops_sp);
+      printf("SP/FULL time ratio: %4.3f x\n\n", ms_sp / ms_full);
+    }
+
+    bool all_passed = full_passed && lse_passed && sp_passed;
+    return all_passed ? cutlass::Status::kSuccess : cutlass::Status::kErrorInternal;
+  }
+};
+
 template <bool Causal,
           bool BlockScale,
           typename TileShapeQK,
@@ -1283,6 +1620,89 @@ struct FMHAConfig {
       } else {
         status = run_with(std::false_type{}, std::false_type{});
       }
+    }
+    CUTLASS_CHECK(status);
+    return 0;
+  }
+
+  // Sequence-parallel / LSE entry point. Runs the FMHA kernel with LSE output
+  // on KV chunks and combines the partials (see SequenceParallelRunner).
+  template <bool isVarLen, bool CachedKV, bool PagedKV, class Scheduler>
+  static int run_lse(const Options &options) {
+    static_assert(!is_same_v<Scheduler, cutlass::fmha::kernel::XeFHMAIndividualPersistentTileScheduler>,
+                  "Sequence-parallel LSE example requires the Individual tile scheduler");
+
+    cutlass::KernelHardwareInfo hw_info;
+    hw_info.sm_count = cutlass::KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+
+    using ProblemShapeType = cutlass::fmha::kernel::FMHAProblemShape<isVarLen>;
+
+    using TiledMMAQK = typename TiledMMAHelper<MMA_Atom<MMAOperation>, Layout<TileShapeQK>, SubgroupLayoutQK>::TiledMMA;
+    using TiledMMAPV = typename TiledMMAHelper<MMA_Atom<MMAOperationPV>, Layout<TileShapePV>, SubgroupLayoutPV>::TiledMMA;
+
+    static_assert(get<0>(TileShapeOutput{}) == get<0>(TileShapePV{}),
+        "Output tile and P*V tile have different sizes in Q dimension");
+    constexpr int VTiles = get<1>(TileShapeOutput{}) / get<1>(TileShapePV{});
+
+    auto make_dummy_tensor = [&](auto val, auto stride) {
+      return make_tensor(make_gmem_ptr(&val),
+                         make_layout(repeat<rank_v<decltype(stride)>>(1), stride));
+    };
+
+    using TensorQ = decltype(make_dummy_tensor(ElementQ{}, StrideQ{}));
+    using TensorK = decltype(make_dummy_tensor(ElementK{}, StrideK{}));
+    using TensorV = decltype(make_dummy_tensor(ElementV{}, StrideV{}));
+    using TensorO = decltype(make_dummy_tensor(ElementO{}, StrideO{}));
+    using TensorScaleQ = decltype(make_dummy_tensor(ElementScale{}, StrideScaleQ{}));
+    using TensorScaleK = decltype(make_dummy_tensor(ElementScale{}, StrideScaleK{}));
+    using TensorScaleV = decltype(make_dummy_tensor(ElementScale{}, StrideScaleV{}));
+
+    using TensorK_cache = TensorK;
+    using TensorV_cache = TensorV;
+    using GmemTiledCopyK_cache = GmemTiledCopyK;
+    using GmemTiledCopyV_cache = GmemTiledCopyV;
+
+    using MainloopDispatchPolicy = cutlass::fmha::XeDefault<PipelineStages>;
+    using CollectiveMainloop = cutlass::fmha::collective::FMHAFwdMainloop<
+        MainloopDispatchPolicy, Causal, BlockScale, F8kvF16mma, PerTensorScale,
+        CachedKV, PagedKV, TiledMMAQK, TiledMMAPV, VTiles,
+        TensorQ, TensorK, TensorV,
+        TensorScaleQ, TensorScaleK, TensorScaleV,
+        TensorK_cache, TensorV_cache,
+        GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV,
+        GmemTiledCopyK_cache, GmemTiledCopyV_cache
+    >;
+
+    using CollectiveEpilogue = cutlass::fmha::collective::FMHAFwdEpilogue<
+        CollectiveMainloop,
+        TileShapeOutput,
+        TensorO,
+        GmemTiledCopyO
+    >;
+
+    cutlass::Status status;
+    auto run_with = [&](auto bo_t, auto hgo_t) -> cutlass::Status {
+      constexpr bool BO  = decltype(bo_t)::value;
+      constexpr bool HGO = decltype(hgo_t)::value;
+      using SchedulerSpec = cutlass::fmha::kernel::XeFHMAIndividualTileScheduler<BO, HGO>;
+      using FMHAKernel = cutlass::fmha::kernel::XeFMHAFwdKernel<
+          ProblemShapeType, CollectiveMainloop, CollectiveEpilogue, SchedulerSpec>;
+      SequenceParallelRunner<FMHAKernel, isVarLen> runner;
+      return runner.run_sp(options, hw_info);
+    };
+
+    const bool batch_one = (options.batch == 1);
+    const bool no_gqa    = (options.num_heads_q == options.num_heads_kv);
+
+    if (batch_one && no_gqa) {
+      status = run_with(std::true_type{},  std::true_type{});
+    }
+    else if (batch_one) {
+      status = run_with(std::true_type{},  std::false_type{});
+    } else if (no_gqa) {
+      status = run_with(std::false_type{}, std::true_type{});
+    } else {
+      status = run_with(std::false_type{}, std::false_type{});
     }
     CUTLASS_CHECK(status);
     return 0;

--- a/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
+++ b/examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp
@@ -1677,7 +1677,8 @@ struct FMHAConfig {
         CollectiveMainloop,
         TileShapeOutput,
         TensorO,
-        GmemTiledCopyO
+        GmemTiledCopyO,
+        /*EnableLSE=*/true
     >;
 
     cutlass::Status status;


### PR DESCRIPTION
---

## 1. Summary

This PR adds an optional **log-sum-exp (LSE) output** to the Flash Attention
forward kernel (`XeFMHAFwdKernel` / `XeFMHAFwdDynamicSplitKernel`) and adds a
dedicated example that uses it to validate **sequence-parallel (SP)** attention:
precision (against a full-sequence reference) and performance (full single
launch vs. chunked SP launches).

The LSE per query row is:

$$LSE_q = m_q + \log_2\!\Big(\sum_s e^{(S_{qs} - m_q)}\Big), \qquad m_q = \max_s S_{qs}$$

where $S_{qs}$ are the scaled attention scores (the kernel softmax is
$\exp_2$-based, so the LSE is naturally in **base 2**). With the per-chunk
$(O_c, LSE_c)$ produced by splitting the KV sequence, the exact SP combine is:

$$M = \max_c LSE_c, \qquad w_c = 2^{(LSE_c - M)}, \qquad O = \frac{\sum_c w_c\, O_c}{\sum_c w_c}$$

The PR is split into two logical parts:

1. **Kernel feature** — LSE output configuration in the FMHA forward epilogue/kernel.
2. **Example** — `flash_attention_LSE`: an SP precision + performance test built on the LSE output.

---

## 2. Motivation

* **Sequence parallelism.** Long-context attention (ring attention, split-KV
  across GPUs/WGs) requires each partition to emit a partial output plus its
  LSE so a consumer can exactly renormalize partial results. Until now the FMHA
  forward kernel only returned $O$; the LSE enables exact SP recombination.
* **Other consumers.** Attention partition functions (LSE) are also used by
  e.g. long-context re-weighting, ALiBi-style scaling, and multi-GPU decode.

---

## 3. Kernel feature design

### 3.1 Kernel arguments

* `KernelArguments` of both `XeFMHAFwdKernel` and `XeFMHAFwdDynamicSplitKernel`
  gain a field:
  ```cpp
  float *Lse = nullptr;   // LSE output buffer (null = skip)
  ```
* `to_underlying_arguments()` forwards `Lse` (plus `seq_len_qo` and
  `num_heads_q`) into the epilogue `Arguments`/`Params` when non-null.

### 3.2 Epilogue

`FMHAFwdEpilogue`:

* `Arguments`/`Params` gain `lse_ptr`, `seq_len_qo`, `num_heads_q`
  (all defaulted to skip when `lse_ptr == nullptr`).
* `operator()` gains `head_q` and `idx_b` (needed to index the LSE buffer),
  alongside the existing `v_scale` (fp8 path). The merged signature is:
  ```cpp
  operator()(O, tArA, tA_max, tA_sum, blk_qv, thr_id, head_q, idx_b, v_scale = 1.0f)
  ```
* LSE is written per Q row in layout `[batch][num_heads_q][seq_len_qo]`:
  ```cpp
  lse_ptr[idx_b * num_heads_q * seq_len_qo + head_q * seq_len_qo + q] =
      tA_max_row + log(1 / rA_sum_row) * kLog2e;   // kLog2e = log2(e)
  ```
  The row max/sum are fetched with `broadcast<0>(tA_max/rA_sum, rA, i)` — the
  same per-row access the O store uses — and the target Q row comes from
  `tOgO(i)` (the **global** coordinate tensor of the O store). Each `(q,v)`
  element is owned by exactly one work-item, so writing only the `v==0`
  element of each row writes every Q row exactly once.

> Note: this corrects the earlier LSE write logic, which indexed the max/sum
> fragments with a linear `sg_id * q_per_sg + i` guess that did not match the
> actual fragment layout, and which double-counted the Q-tile offset (it
> assumed local coords while `tOgO` carries global coords), leaving Q-tile ≥ 1
> rows unwritten. The new logic is derived from the O-store coordinate mapping
> and is validated against a host log-sum-exp reference (max abs err ≈ 7.6e-6).

---

## 4. Example design (`flash_attention_LSE`)

New example `06_xe_fmha_fwd_lse.cpp` + `SequenceParallelRunner` in
`xe_fmha_fwd_runner.hpp`:

1. The full KV sequence of length $S$ is split into `sp_chunks` contiguous
   chunks of `--seq_chunk_len` tokens.
2. For each chunk, the kernel is launched with `seq_len_kv = chunk_len`,
   pointing `K`/`V` at the chunk slice of the full buffers **while keeping the
   full-tensor strides** (the buffers are flat contiguous `[B, H, S, D]`,
   mirroring the varlen stride handling). Each launch emits a partial output
   $O_c$ and its LSE $LSE_c$.
3. Partials are combined on the host with the exact SP formula above.
4. Validation:
   * **Full-kernel output** (single launch with LSE) vs. reference → `verify()`.
   * **Kernel LSE** vs. a host log-sum-exp reference (max abs err reported).
   * **SP-combined output** vs. the full-sequence reference → `verify()`.
5. Performance: times the single full launch vs. the chunked SP launches
   (both with LSE enabled) and reports the SP/FULL ratio.

Current restrictions of the example: bf16, non-causal, non-varlen, no
cached/paged KV (the kernel feature itself is not restricted to these).

### New CLI option

* `--seq_chunk_len=<int>` — KV chunk length for sequence-parallel runs
  (`<= 0` ⇒ single full chunk).

---

## 5. Files changed

| File | Change |
|---|---|
| `applications/flash_attention_v2/collective/xe_fmha_fwd_epilogue.hpp` | LSE output config (`Arguments`/`Params`/ctor), `head_q`/`idx_b` params, LSE write logic (corrected) |
| `applications/flash_attention_v2/kernel/xe_fmha_fwd_kernel.hpp` | `float *Lse` in both kernels' `KernelArguments`; forward LSE to epilogue; pass `head_q`/`idx_b` at the epilogue call sites |
| `examples/06_bmg_flash_attention/xe_fmha_fwd_runner.hpp` | `--seq_chunk_len` option; `SequenceParallelRunner`; `FMHAConfig::run_lse` |
| `examples/06_bmg_flash_attention/06_xe_fmha_fwd_lse.cpp` | New example (new file) |
| `examples/06_bmg_flash_attention/CMakeLists.txt` | Register `06_xe_fmha_fwd_lse_*` targets (bf16) + `--seq_chunk_len` test option |

---

## 6. Testing

Build (Intel oneAPI, BMG target):

```bash
ninja 06_xe_fmha_fwd_lse_bfloat16_t_hdim64 06_xe_fmha_fwd_lse_bfloat16_t_hdim128
```

Run:

```bash
./examples/sycl/06_bmg_flash_attention/06_xe_fmha_fwd_lse_bfloat16_t_hdim128 \
    --batch=2 --num_heads_q=4 --num_heads_kv=4 \
    --seq_len_qo=256 --seq_len_kv=256 --seq_chunk_len=128 \
    --iterations=20 --warmup=5
```

Results — all configurations pass all three checks:

| Config (hdim) | Q-tiles | SP chunks | Full O | LSE vs ref (max err) | SP combined |
|---|---|---|---|---|---|
| 128, qo=256 kv=256 | 1 | 2 | ✅ | 7.6e-6 | ✅ |
| 128, qo=512 kv=256 | 2 | 2 | ✅ | 7.6e-6 | ✅ |
| 128, qo=768 kv=256 | 3 | 2 | ✅ | 1.5e-5 | ✅ |
| 128, qo=256 kv=1024 | 1 | 8 | ✅ | 7.6e-6 | ✅ |
| 128, qo=512 kv=512 GQA(kv=1) | 2 | 2 | ✅ | 7.6e-6 | ✅ |
| 64,  qo=512 kv=512 | 2 | 4 | ✅ | 7.6e-6 | ✅ |
| 64,  qo=1024 kv=1024 | 4 | 8 | ✅ | 7.6e-6 | ✅ |

Example performance (hdim128, bf16, non-causal, 20 iters; Full vs SP measured
in alternating order and averaged to reduce bias):

| Problem (qo × kv) | SP chunks | Full (ms) | SP (ms) | SP/FULL |
|---|---|---|---|---|
| 256 × 256 | 2 | 0.056 | 0.081 | 1.46x |
| 512 × 512 | 2 | 0.089 | 0.111 | 1.24x |
| 1024 × 4096 | 2 | 0.56 | 0.50 | 0.89x* |
| 1024 × 4096 | 4 | 0.40 | 0.45 | 1.13x |
| 1024 × 4096 | 8 | 0.55 | 0.60 | 1.10x |

\* SP slightly faster than Full at 2 chunks is within measurement noise.

What SP/FULL means: it is the **single-device partitioning overhead** — the
wall time of *all* chunk kernels launched back-to-back on one device divided by
the wall time of a single full-sequence launch. Each chunk is independent and
carries ~1/N of the work, so with SP the chunks can be distributed across N
devices/work-groups for an ideal multi-device wall time of ≈ Full/N (≈ N×
speedup). This example measures the correctness of that decomposition and its
single-device overhead (extra launches, per-chunk softmax normalization), not
the cross-device speedup itself.

The partitioning overhead shrinks as the problem grows: at qo=1024, kv=4096 the
chunked launches are compute-bound and SP/FULL ≈ 1.1x, vs ~1.5x at the small
qo=256, kv=256 case where launch overhead dominates. The absolute `ms` values
are subject to GPU DVFS noise (run-to-run variance on this machine is roughly
±20–40%); the SP/FULL ratio is the more reliable figure.

---

## 7. Notes / follow-up

* The kernel LSE is in **base 2** (consistent with the `exp2` softmax); the SP
  combine uses `exp2f(LSE_c - M)`.
* The example currently supports bf16 non-causal prefill only. Extending to
  causal (chunk-local masks), varlen, cached KV, and fp8 are natural follow-ups.
* Suggest splitting into two commits/PRs if reviewers prefer: (a) kernel
  feature, (b) example + runner.

---

## 8. Checklist

- [x] Rebased onto latest `upstream/main` (`87f68506`)
- [x] Commit history clean (no build artifacts / `.cache` files)
- [x] `ninja` builds: `06_xe_fmha_fwd_lse_bfloat16_t_hdim{64,128}`
- [x] Precision: full O, kernel LSE, SP-combined O all pass across hdim64/128,
      multi Q-tile, 2/4/8 chunks, GQA