### PR TITLE
Add BMG INT8/INT4 GEMM Templates, Fused Dequantization, and Block-Scaled Integer GEMM

### DIFF
--- a/examples/00_bmg_gemm/00_bmg_gemm.cpp
+++ b/examples/00_bmg_gemm/00_bmg_gemm.cpp
@@ -235,6 +235,13 @@ struct ExampleRunner {
     stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(M, N, L));
     stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N, L));
 
+#if defined(CUTLASS_BMG_GEMM_INT4)
+    if (L > 1) {
+      get<2>(stride_A) = static_cast<int64_t>(M) * K / 2;
+      get<2>(stride_B) = static_cast<int64_t>(N) * K / 2;
+    }
+#endif
+
     block_A.reset(static_cast<std::size_t>(M) * K * L);
     block_B.reset(static_cast<std::size_t>(K) * N * L);
     block_C.reset(static_cast<std::size_t>(M) * N * L);

--- a/examples/00_bmg_gemm/00_bmg_gemm.cpp
+++ b/examples/00_bmg_gemm/00_bmg_gemm.cpp
@@ -251,11 +251,14 @@ struct ExampleRunner {
 
     initialize(problem_size);
 
+    ElementCompute alpha = static_cast<ElementCompute>(options.alpha);
+    ElementCompute beta = static_cast<ElementCompute>(options.beta);
+
     typename Gemm::GemmKernel::Arguments arguments{
       cutlass::gemm::GemmUniversalMode::kGemm,
       problem_size,
       {block_A.get(), stride_A, block_B.get(), stride_B},
-      {{options.alpha, options.beta}, block_C.get(), stride_C, block_D.get(), stride_D},
+      {{alpha, beta}, block_C.get(), stride_C, block_D.get(), stride_D},
       hw_info
     };
 
@@ -295,9 +298,13 @@ struct ExampleRunner {
       compat::wait();
 
       float cute_time = timer.seconds() / options.iterations;
-      double tflops = (2.0 * options.m * options.n * options.k * options.l) * 1e-12;
+      double operations = (2.0 * options.m * options.n * options.k * options.l) * 1e-12;
       std::cout << "Problem Size: " << options.m << 'x' << options.n << 'x' << options.k << 'x' << options.l << std::endl;
-      printf("Cutlass GEMM Performance:     [%4.3f]TFlop/s  (%6.4f)ms\n", tflops / cute_time, cute_time*1000);
+    #if defined(CUTLASS_BMG_GEMM_INT4) || defined(CUTLASS_BMG_GEMM_INT8)
+      printf("Cutlass GEMM Performance:     [%4.3f]TOPS    (%6.4f)ms\n", operations / cute_time, cute_time*1000);
+    #else
+      printf("Cutlass GEMM Performance:     [%4.3f]TFlop/s  (%6.4f)ms\n", operations / cute_time, cute_time*1000);
+    #endif
     }
 
     return cutlass::Status::kSuccess;
@@ -341,14 +348,32 @@ int main(int argc, const char** argv)
 
   // The code section below describes datatype for input, output matrices and computation between
   // elements in input matrices.
+#if defined(CUTLASS_BMG_GEMM_INT4)
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = int32_t;
+  using ElementInputA = int4_t;
+  using ElementInputB = int4_t;
+  using ElementOutput = int32_t;
+#elif defined(CUTLASS_BMG_GEMM_INT8)
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = int32_t;
+  using ElementInputA = int8_t;
+  using ElementInputB = int8_t;
+  using ElementOutput = int32_t;
+#else
   using ElementAccumulator = float;      // <- data type of accumulator
   using ElementComputeEpilogue = float;  // <- data type of epilogue operations
   using ElementInputA = bfloat16_t;      // <- data type of elements in input matrix A
   using ElementInputB = bfloat16_t;      // <- data type of elements in input matrix B
   using ElementOutput = float;           // <- data type of elements in output matrix D
+#endif
 
   using LayoutA = cutlass::layout::RowMajor;
+#if defined(CUTLASS_BMG_GEMM_INT4_PACKED_B)
+  using LayoutB = cutlass::layout::ColumnMajor;
+#else
   using LayoutB = cutlass::layout::RowMajor;
+#endif
   using LayoutC = cutlass::layout::RowMajor;
   using LayoutD = cutlass::layout::RowMajor;
 
@@ -360,8 +385,15 @@ int main(int argc, const char** argv)
   using GmemTiledCopyA = void; //XE_LOAD_2D<16, 32, 32>;
   using GmemTiledCopyB = void; //XE_LOAD_2D_VNNI<16, 32, 32>;
 
-  // Workgroup-level tile
+  // Workgroup-level tile. The INT8 path uses two DPAS K steps per global-memory
+  // tile, while INT4 uses one step because its native DPAS K is 64.
+#if defined(CUTLASS_BMG_GEMM_INT4)
+  using TileShape = Shape<_256, _256, _64>;
+#elif defined(CUTLASS_BMG_GEMM_INT8)
+  using TileShape = Shape<_256, _256, _64>;
+#else
   using TileShape = Shape<_256, _256, _32>;
+#endif
 
   // A TiledMMA struct defines a tiling of an MMA atom over M, N and K, combining both additional
   // hardware (sub-groups for Intel BMG) and iterations by each sub-group.
@@ -374,7 +406,16 @@ int main(int argc, const char** argv)
   // each sub-group operates on a contiguous 32x64x32 chunk (4x4x2 iterations). See
   // 0t_mma_atom.md#TiledMMAs for more info. Sub-groups are arranged row-major (stride 4,1,0) for
   // performance reasons.
-  using TiledMma = typename TiledMMAHelper<MMA_Atom<XE_DPAS_TT<8, float, cute::bfloat16_t>>, Layout<TileShape>, Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>>::TiledMMA;
+#if defined(CUTLASS_BMG_GEMM_INT4)
+  using SubgroupLayout = Layout<Shape<_4, _8, _1>, Stride<_8, _1, _0>>;
+#else
+  using SubgroupLayout = Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>;
+#endif
+
+    using TiledMma = typename TiledMMAHelper<
+      MMA_Atom<XE_DPAS_TT<8, ElementAccumulator, ElementInputA, ElementInputB>>,
+      Layout<TileShape>,
+    SubgroupLayout>::TiledMMA;
 
   // For Intel BMG, PipelineStages defines how many k-blocks ahead to prefetch from A and B.
   constexpr int PipelineStages = 2;
@@ -425,7 +466,8 @@ int main(int argc, const char** argv)
   using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
           Shape<int, int, int, int>, // Defer global problem shape definition to runtime
           CollectiveMainloop,
-          CollectiveEpilogue
+      CollectiveEpilogue,
+      void
   >;
 
   // The GemmUniversalAdapter wraps the defined GEMM kernel and handles the launch, and e.g.

--- a/examples/00_bmg_gemm/00_bmg_gemm_int4_block_scaled.cpp
+++ b/examples/00_bmg_gemm/00_bmg_gemm_int4_block_scaled.cpp
@@ -1,0 +1,402 @@
+/***************************************************************************************************
+ * Copyright (C) 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+/*! \file
+    \brief BMG INT4 GEMM with K-blocked A and B dequantization.
+
+    A and B use signed INT4 inputs. A has one scale per M row and K block, while B has one
+    scale per N channel and K block. The mainloop drains each INT32 K-block accumulator into
+    an FP32 fragment before the epilogue applies alpha and beta.
+*/
+
+#include "cutlass/epilogue/collective/xe_epilogue.hpp"
+#include "cutlass/epilogue/fusion/callbacks.hpp"
+#include "cutlass/gemm/device/gemm_universal.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_mma.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+#include "cutlass/util/initialize_block.hpp"
+
+#include <cute/tensor.hpp>
+#include <random>
+#include <vector>
+
+#include "cutlass/util/command_line.h"
+#include "cutlass/util/device_memory.h"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/reference/device/gemm_complex.h"
+#include "cutlass/util/reference/device/tensor_compare.h"
+#include "sycl_common.hpp"
+#include "helper.h"
+
+using namespace cute;
+
+struct Options {
+  bool help = false;
+  bool error = false;
+  int m = 512;
+  int n = 512;
+  int k = 512;
+  int l = 1;
+  int iterations = 20;
+  int verify = 1;
+  float alpha = 1.0f;
+  float beta = 0.0f;
+
+  void parse(int argc, char const** args) {
+    cutlass::CommandLine cmd(argc, args);
+    if (cmd.check_cmd_line_flag("help")) {
+      help = true;
+      return;
+    }
+    cmd.get_cmd_line_argument("m", m, m);
+    cmd.get_cmd_line_argument("n", n, n);
+    cmd.get_cmd_line_argument("k", k, k);
+    cmd.get_cmd_line_argument("l", l, l);
+    cmd.get_cmd_line_argument("alpha", alpha, alpha);
+    cmd.get_cmd_line_argument("beta", beta, beta);
+    cmd.get_cmd_line_argument("iterations", iterations, iterations);
+    cmd.get_cmd_line_argument("verify", verify, verify);
+  }
+
+  std::ostream& print_usage(std::ostream& out) const {
+    out << "BMG integer K-block-scaled GEMM\n\n"
+        << "Options:\n\n"
+        << "  --help                      If specified, displays this usage statement\n"
+        << "  --m=<int>                   Sets the M extent of the GEMM\n"
+        << "  --n=<int>                   Sets the N extent of the GEMM\n"
+        << "  --k=<int>                   Sets the K extent of the GEMM\n"
+        << "  --l=<int>                   Sets the L extent (batch count) of the GEMM\n"
+        << "  --alpha=<float>             Epilogue scalar alpha\n"
+        << "  --beta=<float>              Epilogue scalar beta\n"
+        << "  --iterations=<int>          Iterations\n"
+        << "  --verify=<int>              Specify whether to verify\n\n";
+    return out;
+  }
+};
+
+template <class Gemm, int GroupK>
+struct ExampleRunner {
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using StrideD = typename Gemm::GemmKernel::StrideD;
+  using LayoutA = typename Gemm::LayoutA;
+  using LayoutB = typename Gemm::LayoutB;
+  using LayoutC = typename Gemm::LayoutC;
+  using LayoutD = typename Gemm::LayoutD;
+  using ElementA = typename Gemm::ElementA;
+  using ElementB = typename Gemm::ElementB;
+  using ElementOutput = typename Gemm::ElementD;
+  using ElementCompute = typename Gemm::CollectiveEpilogue::ElementCompute;
+  using ElementScale = float;
+  using StrideScaleA = Stride<_1, int64_t, int64_t>;
+  using StrideScaleB = Stride<_1, int64_t, int64_t>;
+  using ProblemShapeType = typename Gemm::GemmKernel::ProblemShape;
+
+  StrideA stride_A;
+  StrideB stride_B;
+  StrideC stride_C;
+  StrideD stride_D;
+  StrideScaleA stride_scale_A;
+  StrideScaleB stride_scale_B;
+  uint64_t seed = 0;
+
+  cutlass::DeviceAllocation<ElementA> block_A;
+  cutlass::DeviceAllocation<ElementB> block_B;
+  cutlass::DeviceAllocation<ElementOutput> block_C;
+  cutlass::DeviceAllocation<ElementOutput> block_D;
+  cutlass::DeviceAllocation<ElementScale> block_scale_A;
+  cutlass::DeviceAllocation<ElementScale> block_scale_B;
+  cutlass::DeviceAllocation<int32_t> block_ref_accum;
+  cutlass::DeviceAllocation<ElementOutput> block_ref_D;
+
+  std::vector<ElementOutput> host_C;
+  std::vector<ElementScale> host_scale_A;
+  std::vector<ElementScale> host_scale_B;
+
+  void initialize(ProblemShapeType const& problem_size) {
+    auto [M, N, K, L] = cute::append<4>(problem_size, 1);
+    int scale_k = K / GroupK;
+
+    stride_A = cutlass::make_cute_packed_stride(StrideA{}, make_shape(M, K, L));
+    stride_B = cutlass::make_cute_packed_stride(StrideB{}, make_shape(N, K, L));
+    stride_C = cutlass::make_cute_packed_stride(StrideC{}, make_shape(M, N, L));
+    stride_D = cutlass::make_cute_packed_stride(StrideD{}, make_shape(M, N, L));
+    stride_scale_A = cutlass::make_cute_packed_stride(
+        StrideScaleA{}, make_shape(M, scale_k, L));
+    stride_scale_B = cutlass::make_cute_packed_stride(
+        StrideScaleB{}, make_shape(N, scale_k, L));
+
+      if (L > 1) {
+        get<2>(stride_A) = static_cast<int64_t>(M) * K * sizeof_bits_v<ElementA> / 8;
+        get<2>(stride_B) = static_cast<int64_t>(N) * K * sizeof_bits_v<ElementB> / 8;
+    }
+
+    const std::size_t elements_A = static_cast<std::size_t>(M) * K * L;
+    const std::size_t elements_B = static_cast<std::size_t>(N) * K * L;
+    const std::size_t elements_CD = static_cast<std::size_t>(M) * N * L;
+    const std::size_t elements_scale_A = static_cast<std::size_t>(M) * scale_k * L;
+    const std::size_t elements_scale_B = static_cast<std::size_t>(N) * scale_k * L;
+
+    block_A.reset(elements_A);
+    block_B.reset(elements_B);
+    block_C.reset(elements_CD);
+    block_D.reset(elements_CD);
+    block_scale_A.reset(elements_scale_A);
+    block_scale_B.reset(elements_scale_B);
+    block_ref_accum.reset(elements_CD);
+    block_ref_D.reset(elements_CD);
+
+    host_C.resize(elements_CD);
+    host_scale_A.resize(elements_scale_A);
+    host_scale_B.resize(elements_scale_B);
+
+    initialize_block(block_A, seed + 2023);
+    initialize_block(block_B, seed + 2022);
+    initialize_block(block_C, seed + 2021);
+    block_C.copy_to_host(host_C.data());
+    compat::wait();
+
+    for (int batch = 0; batch < L; ++batch) {
+      for (int block = 0; block < scale_k; ++block) {
+        for (int m = 0; m < M; ++m) {
+          host_scale_A[(static_cast<std::size_t>(batch) * scale_k + block) * M + m] =
+              0.015625f * static_cast<float>(1 + ((m + 3 * block + batch) % 7));
+        }
+        for (int n = 0; n < N; ++n) {
+          host_scale_B[(static_cast<std::size_t>(batch) * scale_k + block) * N + n] =
+              0.015625f * static_cast<float>(1 + ((n + 5 * block + batch) % 9));
+        }
+      }
+    }
+
+    block_scale_A.copy_from_host(host_scale_A.data());
+    block_scale_B.copy_from_host(host_scale_B.data());
+  }
+
+  bool verify(ProblemShapeType const& problem_size, Options const& options) {
+    auto [M, N, K, L] = problem_size;
+    const int scale_k = K / GroupK;
+    std::vector<int32_t> host_accum(static_cast<std::size_t>(M) * N * L);
+    std::vector<float> host_expected(static_cast<std::size_t>(M) * N * L);
+
+    cutlass::TensorRef ref_A(block_A.get(), LayoutA::packed({M, K}));
+    cutlass::TensorRef ref_B(block_B.get(), LayoutB::packed({K, N}));
+    cutlass::TensorRef ref_C(block_C.get(), LayoutC::packed({M, N}));
+    cutlass::TensorRef ref_accum(block_ref_accum.get(), LayoutD::packed({M, N}));
+
+    for (int block = 0; block < scale_k; ++block) {
+      auto block_ref_A = ref_A;
+      auto block_ref_B = ref_B;
+      block_ref_A.add_pointer_offset(block * GroupK);
+      block_ref_B.add_pointer_offset(block * GroupK);
+
+      cutlass::reference::device::GemmComplex(
+          {M, N, GroupK},
+          1.0f,
+          block_ref_A,
+          cutlass::ComplexTransform::kNone,
+          block_ref_B,
+          cutlass::ComplexTransform::kNone,
+          0.0f,
+          ref_C,
+          ref_accum,
+          int32_t(0),
+          L,
+          M * K,
+          K * N,
+          M * N,
+          M * N);
+      compat::wait();
+      cutlass::device_memory::copy_to_host(host_accum.data(), block_ref_accum.get(), host_accum.size());
+      compat::wait();
+
+      for (int batch = 0; batch < L; ++batch) {
+        for (int m = 0; m < M; ++m) {
+          const float scale_a = host_scale_A[
+              (static_cast<std::size_t>(batch) * scale_k + block) * M + m];
+          for (int n = 0; n < N; ++n) {
+            const std::size_t index =
+                (static_cast<std::size_t>(batch) * M + m) * N + n;
+            const float scale_b = host_scale_B[
+                (static_cast<std::size_t>(batch) * scale_k + block) * N + n];
+            host_expected[index] +=
+              options.alpha * scale_a * scale_b * host_accum[index];
+          }
+        }
+      }
+    }
+
+    for (std::size_t index = 0; index < host_expected.size(); ++index) {
+      host_expected[index] += options.beta * static_cast<float>(host_C[index]);
+    }
+    std::vector<ElementOutput> host_expected_output(host_expected.size());
+    for (std::size_t index = 0; index < host_expected.size(); ++index) {
+      host_expected_output[index] = static_cast<ElementOutput>(host_expected[index]);
+    }
+    block_ref_D.copy_from_host(host_expected_output.data());
+    compat::wait();
+    return cutlass::reference::device::BlockCompareRelativelyEqual(
+      block_ref_D.get(), block_D.get(), block_D.size(), ElementOutput(1e-2f), ElementOutput(1e-4f));
+  }
+
+  cutlass::Status run(Options const& options, cutlass::KernelHardwareInfo const& hw_info) {
+    ProblemShapeType problem_size{options.m, options.n, options.k, options.l};
+    if (options.k % GroupK != 0) {
+      std::cerr << "K must be divisible by the block size " << GroupK << std::endl;
+      return cutlass::Status::kErrorInvalidProblem;
+    }
+    initialize(problem_size);
+
+    typename Gemm::GemmKernel::Arguments arguments{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        problem_size,
+        {block_A.get(), stride_A, block_B.get(), stride_B,
+         block_scale_A.get(), stride_scale_A, block_scale_B.get(), stride_scale_B},
+        {{options.alpha, options.beta}, block_C.get(), stride_C, block_D.get(), stride_D},
+        hw_info};
+
+    Gemm gemm_op;
+    cutlass::device_memory::allocation<uint8_t> workspace(Gemm::get_workspace_size(arguments));
+    if (gemm_op.can_implement(arguments) != cutlass::Status::kSuccess) {
+      std::cerr << "Invalid Problem Size: "
+                << options.m << 'x' << options.n << 'x' << options.k << 'x' << options.l << std::endl;
+      return cutlass::Status::kErrorInvalidProblem;
+    }
+
+    CUTLASS_CHECK(gemm_op.initialize(arguments, workspace.get()));
+    CUTLASS_CHECK(gemm_op.run());
+    compat::wait();
+
+    if (options.verify != 0) {
+      bool passed = verify(problem_size, options);
+      std::cout << "Disposition: " << (passed ? "Passed" : "Failed") << std::endl;
+      if (!passed) {
+        return cutlass::Status::kErrorInternal;
+      }
+    } else {
+      std::cout << "Disposition is skipped." << std::endl;
+    }
+
+    if (options.iterations > 0) {
+      GPU_Clock timer;
+      timer.start();
+      for (int i = 0; i < options.iterations; ++i) {
+        CUTLASS_CHECK(gemm_op.run());
+      }
+      compat::wait();
+      float elapsed = timer.seconds() / options.iterations;
+      double operations = (2.0 * options.m * options.n * options.k * options.l) * 1e-12;
+      std::cout << "Problem Size: "
+                << options.m << 'x' << options.n << 'x' << options.k << 'x' << options.l << std::endl;
+      printf("Cutlass GEMM Performance:     [%4.3f]TOPS    (%6.4f)ms\n",
+             operations / elapsed, elapsed * 1000);
+    }
+    return cutlass::Status::kSuccess;
+  }
+};
+
+int main(int argc, const char** argv) {
+  Options options;
+  options.parse(argc, argv);
+  if (options.help) {
+    options.print_usage(std::cout) << std::endl;
+    return 0;
+  }
+  if (options.error) {
+    std::cerr << "Aborting execution." << std::endl;
+    return -1;
+  }
+
+#if defined(CUTLASS_BMG_GEMM_INT8_BLOCK_SCALED)
+  using ElementA = int8_t;
+  using ElementB = int8_t;
+  using BlockScaledMmaAtom = XE_DPAS_TT_INT8_BLOCK_SCALED<8>;
+#else
+  using ElementA = int4_t;
+  using ElementB = int4_t;
+  using BlockScaledMmaAtom = XE_DPAS_TT_INT4_BLOCK_SCALED<8>;
+#endif
+#if defined(CUTLASS_BMG_GEMM_BLOCK_SCALED_BF16) || \
+  defined(CUTLASS_BMG_GEMM_INT4_BLOCK_SCALED_BF16)
+  using ElementOutput = bfloat16_t;
+#else
+  using ElementOutput = float;
+#endif
+  using ElementCompute = float;
+  using ElementScale = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+  using LayoutD = cutlass::layout::RowMajor;
+#if defined(CUTLASS_BMG_GEMM_INT8_BLOCK_SCALED)
+  using TileShape = Shape<_256, _128, _64>;
+  using SubgroupLayout = Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>;
+#else
+  using TileShape = Shape<_128, _256, _128>;
+  using SubgroupLayout = Layout<Shape<_4, _8, _1>, Stride<_8, _1, _0>>;
+#endif
+  using TiledMma = typename TiledMMAHelper<
+      MMA_Atom<BlockScaledMmaAtom>,
+      Layout<TileShape>,
+      SubgroupLayout>::TiledMMA;
+  using GmemTiledCopyA = void;
+  using GmemTiledCopyB = void;
+  using GmemTiledCopyScaleA = void;
+  using GmemTiledCopyScaleB = void;
+
+#if defined(CUTLASS_BMG_GEMM_BLOCK_SCALED_256) || \
+  defined(CUTLASS_BMG_GEMM_INT4_BLOCK_SCALED_256)
+  constexpr int GroupK = 256;
+#else
+  constexpr int GroupK = 128;
+#endif
+
+  constexpr int PipelineStages = 2;
+  using MainloopDispatch = cutlass::gemm::MainloopIntelXeXMX16IntBlockScaled<
+      PipelineStages, GroupK>;
+  using EpilogueDispatch = cutlass::epilogue::IntelXeGeneric;
+  using EpilogueOp = cutlass::epilogue::fusion::LinearCombination<
+      ElementOutput, ElementCompute, float, float, cutlass::FloatRoundStyle::round_to_nearest>;
+  using FusionCallbacks = cutlass::epilogue::fusion::FusionCallbacks<
+      EpilogueDispatch, EpilogueOp, TileShape, decltype(tile_shape(TiledMma()))>;
+  using CollectiveEpilogue = cutlass::epilogue::collective::CollectiveEpilogue<
+      EpilogueDispatch,
+      TileShape,
+      void,
+      ElementOutput,
+      cutlass::gemm::TagToStrideC_t<LayoutC>,
+      ElementOutput,
+      cutlass::gemm::TagToStrideC_t<LayoutD>,
+      FusionCallbacks,
+      void,
+      void>;
+  using StrideScaleA = Stride<_1, int64_t, int64_t>;
+  using StrideScaleB = Stride<_1, int64_t, int64_t>;
+  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
+      MainloopDispatch,
+      TileShape,
+      cute::tuple<ElementA, ElementScale>,
+      cute::tuple<cutlass::gemm::TagToStrideA_t<LayoutA>, StrideScaleA>,
+      cute::tuple<ElementB, ElementScale>,
+      cute::tuple<cutlass::gemm::TagToStrideB_t<LayoutB>, StrideScaleB>,
+      TiledMma,
+      cute::tuple<GmemTiledCopyA, GmemTiledCopyScaleA>,
+      void,
+      void,
+      cute::identity,
+      cute::tuple<GmemTiledCopyB, GmemTiledCopyScaleB>,
+      void,
+      void,
+      cute::identity>;
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.sm_count = cutlass::KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+  CUTLASS_CHECK((ExampleRunner<Gemm, GroupK>{}).run(options, hw_info));
+  return 0;
+}

--- a/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant.cpp
+++ b/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant.cpp
@@ -1,0 +1,724 @@
+/***************************************************************************************************
+ * Copyright (C) 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+/*! \file
+    \brief BMG INT4 GEMM with epilogue dequantization.
+
+    The GEMM computes an int32 accumulator from signed int4 A and B. The epilogue then
+    applies either a per-tensor or per-row scale for A and a per-channel scale for B:
+
+      D(m,n) = alpha * scale_a[m] * scale_b(n) * acc(m,n) + beta * C(m,n)
+
+    The fp32 and bf16 C/D variants are built from this source file. The A and B operands
+    use the packed subbyte storage and batch strides required by the BMG INT4 mainloop.
+*/
+
+#include "cutlass/epilogue/collective/xe_epilogue.hpp"
+#include "cutlass/epilogue/fusion/xe_callbacks.hpp"
+#include "cutlass/gemm/device/gemm_universal.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_mma.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+#include "cutlass/util/initialize_block.hpp"
+
+#include <cute/tensor.hpp>
+#include <random>
+#include <vector>
+
+#include "cutlass/util/command_line.h"
+#include "cutlass/util/device_memory.h"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/reference/device/gemm_complex.h"
+#include "cutlass/util/reference/device/tensor_compare.h"
+#include "sycl_common.hpp"
+#include "helper.h"
+
+using namespace cute;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::epilogue::fusion {
+
+template <
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementSource_ = ElementOutput_,
+  class ElementScalar_ = ElementCompute_,
+  int AlignmentScale_ = 128 / sizeof_bits_v<ElementScalar_>,
+  FloatRoundStyle RoundStyle_ = FloatRoundStyle::round_to_nearest
+>
+struct BmgInt4Dequant : FusionOperation {
+  using ElementOutput = ElementOutput_;
+  using ElementCompute = ElementCompute_;
+  using ElementSource = ElementSource_;
+  using ElementScalar = ElementScalar_;
+  static constexpr int AlignmentScalar = AlignmentScale_;
+  static constexpr bool IsSourceSupported = true;
+  static constexpr bool IsPerColScaleSupported = true;
+  static constexpr auto RoundStyle = RoundStyle_;
+};
+
+template <
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementSource_ = ElementOutput_,
+  class ElementScalar_ = ElementCompute_,
+  int AlignmentScale_ = 128 / sizeof_bits_v<ElementScalar_>,
+  FloatRoundStyle RoundStyle_ = FloatRoundStyle::round_to_nearest
+>
+struct BmgInt4DequantPerRowA : FusionOperation {
+  using ElementOutput = ElementOutput_;
+  using ElementCompute = ElementCompute_;
+  using ElementSource = ElementSource_;
+  using ElementScalar = ElementScalar_;
+  static constexpr int AlignmentScalar = AlignmentScale_;
+  static constexpr bool IsSourceSupported = true;
+  static constexpr bool IsPerRowScaleSupported = true;
+  static constexpr bool IsPerColScaleSupported = true;
+  static constexpr auto RoundStyle = RoundStyle_;
+};
+
+template <
+  class CtaTileShapeMNK,
+  class ElementOutput,
+  class ElementCompute,
+  class ElementSource,
+  class ElementScalar,
+  int AlignmentScale,
+  FloatRoundStyle RoundStyle
+>
+using BmgInt4DequantVisitor =
+  XeEVT<
+    XeCompute<homogeneous_multiply_add, ElementOutput, ElementCompute, RoundStyle>,
+    XeScalarBroadcast<ElementScalar, Stride<_0, _0, int64_t>>,
+    XeSrcFetch<ElementSource>,
+    XeEVT<
+      XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+      XeRowBroadcast<
+        0,
+        CtaTileShapeMNK,
+        ElementScalar,
+        ElementCompute,
+        Stride<_0, _1, int64_t>,
+        AlignmentScale>,
+      XeEVT<
+        XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+        XeScalarBroadcast<ElementScalar, Stride<_0, _0, int64_t>, 2>,
+        XeAccFetch
+      >
+    >
+  >;
+
+template <
+  class CtaTileShapeMNK,
+  class ElementOutput,
+  class ElementCompute,
+  class ElementSource,
+  class ElementScalar,
+  int AlignmentScale,
+  FloatRoundStyle RoundStyle
+>
+using BmgInt4DequantPerRowAVisitor =
+  XeEVT<
+    XeCompute<homogeneous_multiply_add, ElementOutput, ElementCompute, RoundStyle>,
+    XeScalarBroadcast<ElementScalar, Stride<_0, _0, int64_t>>,
+    XeSrcFetch<ElementSource>,
+    XeEVT<
+      XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+      XeColBroadcast<
+        0,
+        CtaTileShapeMNK,
+        ElementScalar,
+        ElementCompute,
+        Stride<_1, _0, int64_t>,
+        AlignmentScale>,
+      XeEVT<
+        XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+        XeRowBroadcast<
+          0,
+          CtaTileShapeMNK,
+          ElementScalar,
+          ElementCompute,
+          Stride<_0, _1, int64_t>,
+          AlignmentScale>,
+        XeEVT<
+          XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+          XeScalarBroadcast<ElementScalar, Stride<_0, _0, int64_t>>,
+          XeAccFetch
+        >
+      >
+    >
+  >;
+
+template <
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementSource_,
+  class ElementScalar_,
+  int AlignmentScale_,
+  FloatRoundStyle RoundStyle_,
+  class CtaTileShapeMNK_,
+  class EpilogueTile_
+>
+struct FusionCallbacks<
+    epilogue::IntelXeGeneric,
+    fusion::BmgInt4Dequant<
+      ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, AlignmentScale_, RoundStyle_>,
+    CtaTileShapeMNK_,
+    EpilogueTile_
+> : BmgInt4DequantVisitor<
+      CtaTileShapeMNK_,
+      typename cutlass::detail::get_unpacked_element_type<ElementOutput_>::type,
+      ElementCompute_,
+      ElementSource_,
+      ElementScalar_,
+      AlignmentScale_,
+      RoundStyle_
+    > {
+
+  using ElementOutput = ElementOutput_;
+  using ElementCompute = ElementCompute_;
+  using ElementSource = ElementSource_;
+  using ElementScalar = ElementScalar_;
+  using Operation = fusion::BmgInt4Dequant<
+    ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, AlignmentScale_, RoundStyle_>;
+  using Impl = BmgInt4DequantVisitor<
+    CtaTileShapeMNK_,
+    typename cutlass::detail::get_unpacked_element_type<ElementOutput_>::type,
+    ElementCompute_,
+    ElementSource_,
+    ElementScalar_,
+    AlignmentScale_,
+    RoundStyle_
+  >;
+
+  struct Arguments {
+    ElementScalar alpha = ElementScalar(1);
+    ElementScalar beta = ElementScalar(0);
+    ElementScalar scale_a = ElementScalar(1);
+    ElementScalar const* alpha_ptr = nullptr;
+    ElementScalar const* beta_ptr = nullptr;
+    ElementScalar const* scale_a_ptr = nullptr;
+    ElementScalar const* scale_b_ptr = nullptr;
+
+    using StrideAlpha = Stride<_0, _0, int64_t>;
+    using StrideBeta = Stride<_0, _0, int64_t>;
+    using StrideScaleB = Stride<_0, _1, int64_t>;
+
+    StrideAlpha dAlpha = {_0{}, _0{}, 0};
+    StrideBeta dBeta = {_0{}, _0{}, 0};
+    StrideAlpha dScaleA = {_0{}, _0{}, 0};
+    StrideScaleB dScaleB = {_0{}, _1{}, 0};
+
+    operator typename Impl::Arguments() const {
+      return {
+        {{beta}, {beta_ptr}, {dBeta}},
+        {},
+        {
+          {scale_b_ptr, ElementScalar(1), dScaleB},
+          {
+            {{scale_a, alpha}, {scale_a_ptr, alpha_ptr}, {dScaleA, dAlpha}},
+            {},
+            {}
+          },
+          {}
+        },
+        {}
+      };
+    }
+  };
+
+  using Impl::Impl;
+};
+
+template <
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementSource_,
+  class ElementScalar_,
+  int AlignmentScale_,
+  FloatRoundStyle RoundStyle_,
+  class CtaTileShapeMNK_,
+  class EpilogueTile_
+>
+struct FusionCallbacks<
+    epilogue::IntelXeGeneric,
+    fusion::BmgInt4DequantPerRowA<
+      ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, AlignmentScale_, RoundStyle_>,
+    CtaTileShapeMNK_,
+    EpilogueTile_
+> : BmgInt4DequantPerRowAVisitor<
+      CtaTileShapeMNK_,
+      typename cutlass::detail::get_unpacked_element_type<ElementOutput_>::type,
+      ElementCompute_,
+      ElementSource_,
+      ElementScalar_,
+      AlignmentScale_,
+      RoundStyle_
+    > {
+
+  using ElementOutput = ElementOutput_;
+  using ElementCompute = ElementCompute_;
+  using ElementSource = ElementSource_;
+  using ElementScalar = ElementScalar_;
+  using Operation = fusion::BmgInt4DequantPerRowA<
+    ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, AlignmentScale_, RoundStyle_>;
+  using Impl = BmgInt4DequantPerRowAVisitor<
+    CtaTileShapeMNK_,
+    typename cutlass::detail::get_unpacked_element_type<ElementOutput_>::type,
+    ElementCompute_,
+    ElementSource_,
+    ElementScalar_,
+    AlignmentScale_,
+    RoundStyle_
+  >;
+
+  struct Arguments {
+    ElementScalar alpha = ElementScalar(1);
+    ElementScalar beta = ElementScalar(0);
+    ElementScalar const* alpha_ptr = nullptr;
+    ElementScalar const* beta_ptr = nullptr;
+    ElementScalar const* scale_a_ptr = nullptr;
+    ElementScalar const* scale_b_ptr = nullptr;
+
+    using StrideAlpha = Stride<_0, _0, int64_t>;
+    using StrideBeta = Stride<_0, _0, int64_t>;
+    using StrideScaleA = Stride<_1, _0, int64_t>;
+    using StrideScaleB = Stride<_0, _1, int64_t>;
+
+    StrideAlpha dAlpha = {_0{}, _0{}, 0};
+    StrideBeta dBeta = {_0{}, _0{}, 0};
+    StrideScaleA dScaleA = {_1{}, _0{}, 0};
+    StrideScaleB dScaleB = {_0{}, _1{}, 0};
+
+    operator typename Impl::Arguments() const {
+      return {
+        {{beta}, {beta_ptr}, {dBeta}},
+        {},
+        {
+          {scale_a_ptr, ElementScalar(1), dScaleA},
+          {
+            {scale_b_ptr, ElementScalar(1), dScaleB},
+            {
+              {{alpha}, {alpha_ptr}, {dAlpha}},
+              {},
+              {}
+            },
+            {}
+          },
+          {}
+        },
+        {}
+      };
+    }
+  };
+
+  using Impl::Impl;
+};
+
+} // namespace cutlass::epilogue::fusion
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Options {
+  bool help;
+  bool error;
+
+  int m, n, k, l, iterations, verify;
+  float alpha, beta, scale_a;
+
+  Options()
+    : help(false),
+      error(false),
+      m(5120),
+      n(4096),
+      k(4096),
+      l(1),
+      iterations(100),
+      verify(1),
+      alpha(1.f),
+      beta(0.f),
+      scale_a(0.125f) {}
+
+  void parse(int argc, char const** args) {
+    cutlass::CommandLine cmd(argc, args);
+
+    if (cmd.check_cmd_line_flag("help")) {
+      help = true;
+      return;
+    }
+
+    cmd.get_cmd_line_argument("m", m, 5120);
+    cmd.get_cmd_line_argument("n", n, 4096);
+    cmd.get_cmd_line_argument("k", k, 4096);
+    cmd.get_cmd_line_argument("l", l, 1);
+    cmd.get_cmd_line_argument("alpha", alpha, 1.f);
+    cmd.get_cmd_line_argument("beta", beta, 0.f);
+    cmd.get_cmd_line_argument("scale-a", scale_a, 0.125f);
+    cmd.get_cmd_line_argument("iterations", iterations, 100);
+    cmd.get_cmd_line_argument("verify", verify, 1);
+  }
+
+  std::ostream& print_usage(std::ostream& out) const {
+    out << "BMG INT4 GEMM with epilogue dequantization\n\n"
+      << "Options:\n\n"
+      << "  --help                      If specified, displays this usage statement\n\n"
+      << "  --m=<int>                   Sets the M extent of the GEMM\n"
+      << "  --n=<int>                   Sets the N extent of the GEMM\n"
+      << "  --k=<int>                   Sets the K extent of the GEMM\n"
+      << "  --l=<int>                   Sets the L extent (batch count) of the GEMM\n"
+      << "  --alpha=<float>             Additional epilogue scale\n"
+      << "  --beta=<float>              Epilogue C scale\n"
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+      << "  --scale-a=<float>           Base value for the generated A per-row scales\n"
+#else
+      << "  --scale-a=<float>           A per-tensor dequantization scale\n"
+#endif
+      << "  --iterations=<int>          Iterations\n"
+      << "  --verify=<int>              Specify whether to verify\n\n";
+    return out;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class Gemm>
+struct ExampleRunner {
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using StrideD = typename Gemm::GemmKernel::StrideD;
+
+  using LayoutA = typename Gemm::LayoutA;
+  using LayoutB = typename Gemm::LayoutB;
+  using LayoutC = typename Gemm::LayoutC;
+  using LayoutD = typename Gemm::LayoutD;
+
+  using ElementA = typename Gemm::ElementA;
+  using ElementB = typename Gemm::ElementB;
+  using ElementAccumulator = typename Gemm::ElementAccumulator;
+  using CollectiveEpilogue = typename Gemm::CollectiveEpilogue;
+  using ElementC = typename Gemm::ElementC;
+  using ElementOutput = typename CollectiveEpilogue::ElementOutput;
+  using ElementCompute = typename CollectiveEpilogue::ElementCompute;
+  using ProblemShapeType = typename Gemm::GemmKernel::ProblemShape;
+
+  using ElementScale = float;
+  using StrideScaleB = typename CollectiveEpilogue::FusionCallbacks::Arguments::StrideScaleB;
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+  using StrideScaleA = typename CollectiveEpilogue::FusionCallbacks::Arguments::StrideScaleA;
+#endif
+
+  StrideA stride_A;
+  StrideB stride_B;
+  StrideC stride_C;
+  StrideD stride_D;
+  uint64_t seed = 0;
+
+  cutlass::DeviceAllocation<ElementA> block_A;
+  cutlass::DeviceAllocation<ElementB> block_B;
+  cutlass::DeviceAllocation<ElementC> block_C;
+  cutlass::DeviceAllocation<ElementScale> block_scale_B;
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+  cutlass::DeviceAllocation<ElementScale> block_scale_A;
+#endif
+  cutlass::DeviceAllocation<ElementOutput> block_D;
+  cutlass::DeviceAllocation<ElementAccumulator> block_ref_accum;
+  cutlass::DeviceAllocation<ElementOutput> block_ref_D;
+
+  std::vector<ElementC> host_C;
+  std::vector<ElementScale> host_scale_B;
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+  std::vector<ElementScale> host_scale_A;
+#endif
+
+  void initialize(const ProblemShapeType& problem_size, float scale_a) {
+    auto problem_shape_MNKL = cute::append<4>(problem_size, 1);
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    stride_A = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, L));
+    stride_B = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N, K, L));
+    stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(M, N, L));
+    stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N, L));
+
+    if (L > 1) {
+      get<2>(stride_A) = static_cast<int64_t>(M) * K / 2;
+      get<2>(stride_B) = static_cast<int64_t>(N) * K / 2;
+    }
+
+    std::size_t elements_A = static_cast<std::size_t>(M) * K * L;
+    std::size_t elements_B = static_cast<std::size_t>(K) * N * L;
+    std::size_t elements_C = static_cast<std::size_t>(M) * N * L;
+
+    block_A.reset(elements_A);
+    block_B.reset(elements_B);
+    block_C.reset(elements_C);
+    block_scale_B.reset(static_cast<std::size_t>(N));
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+    block_scale_A.reset(static_cast<std::size_t>(M));
+#endif
+    block_D.reset(elements_C);
+    block_ref_accum.reset(elements_C);
+    block_ref_D.reset(elements_C);
+
+    host_C.resize(elements_C);
+    host_scale_B.resize(static_cast<std::size_t>(N));
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+    host_scale_A.resize(static_cast<std::size_t>(M));
+#endif
+
+    initialize_block(block_A, seed + 2023);
+    initialize_block(block_B, seed + 2022);
+    initialize_block(block_C, seed + 2021);
+    block_C.copy_to_host(host_C.data());
+    compat::wait();
+
+    for (int n = 0; n < N; ++n) {
+      host_scale_B[n] = 0.015625f * static_cast<float>(1 + (n % 7));
+    }
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+    for (int m = 0; m < M; ++m) {
+      host_scale_A[m] = scale_a * (0.5f + 0.125f * static_cast<float>(m % 5));
+    }
+#endif
+
+    block_scale_B.copy_from_host(host_scale_B.data());
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+    block_scale_A.copy_from_host(host_scale_A.data());
+#endif
+  }
+
+  bool verify(const ProblemShapeType& problem_size, const Options& options) {
+    auto [M, N, K, L] = problem_size;
+
+    cutlass::TensorRef ref_A(block_A.get(), LayoutA::packed({M, K}));
+    cutlass::TensorRef ref_B(block_B.get(), LayoutB::packed({K, N}));
+    cutlass::TensorRef ref_C(block_C.get(), LayoutC::packed({M, N}));
+    cutlass::TensorRef ref_accum(block_ref_accum.get(), LayoutD::packed({M, N}));
+
+    cutlass::reference::device::GemmComplex(
+      {M, N, K},
+      ElementCompute(1),
+      ref_A,
+      cutlass::ComplexTransform::kNone,
+      ref_B,
+      cutlass::ComplexTransform::kNone,
+      ElementCompute(0),
+      ref_C,
+      ref_accum,
+      ElementAccumulator(0),
+      L,
+      M * K,
+      K * N,
+      M * N,
+      M * N);
+
+    compat::wait();
+
+    std::size_t elements_D = static_cast<std::size_t>(M) * N * L;
+    std::vector<ElementAccumulator> host_accum(elements_D);
+    std::vector<ElementOutput> host_expected(elements_D);
+    cutlass::device_memory::copy_to_host(host_accum.data(), block_ref_accum.get(), elements_D);
+    compat::wait();
+
+    for (int l = 0; l < L; ++l) {
+      for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+          std::size_t index =
+            (static_cast<std::size_t>(l) * M + m) * N + n;
+          float scale_a = options.scale_a;
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+          scale_a = host_scale_A[m];
+#endif
+          float value =
+            options.alpha * scale_a * host_scale_B[n] * static_cast<float>(host_accum[index]);
+          value += options.beta * static_cast<float>(host_C[index]);
+          host_expected[index] = static_cast<ElementOutput>(value);
+        }
+      }
+    }
+
+    block_ref_D.copy_from_host(host_expected.data());
+    compat::wait();
+
+    ElementOutput epsilon(1e-2f);
+    ElementOutput non_zero_floor(1e-4f);
+    return cutlass::reference::device::BlockCompareRelativelyEqual(
+      block_ref_D.get(), block_D.get(), block_D.size(), epsilon, non_zero_floor);
+  }
+
+  cutlass::Status run(const Options& options, const cutlass::KernelHardwareInfo& hw_info) {
+    ProblemShapeType problem_size = {options.m, options.n, options.k, options.l};
+    initialize(problem_size, options.scale_a);
+
+    typename Gemm::GemmKernel::EpilogueArguments epilogue_arguments{
+      {}, block_C.get(), stride_C, block_D.get(), stride_D};
+    epilogue_arguments.thread.alpha = static_cast<ElementCompute>(options.alpha);
+    epilogue_arguments.thread.beta = static_cast<ElementCompute>(options.beta);
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+    epilogue_arguments.thread.scale_a_ptr = block_scale_A.get();
+    epilogue_arguments.thread.dScaleA = StrideScaleA{};
+#else
+    epilogue_arguments.thread.scale_a = static_cast<ElementCompute>(options.scale_a);
+#endif
+    epilogue_arguments.thread.scale_b_ptr = block_scale_B.get();
+    epilogue_arguments.thread.dScaleB = StrideScaleB{};
+
+    typename Gemm::GemmKernel::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      problem_size,
+      {block_A.get(), stride_A, block_B.get(), stride_B},
+      epilogue_arguments,
+      hw_info};
+
+    Gemm gemm_op;
+    std::size_t workspace_size = Gemm::get_workspace_size(arguments);
+    cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+    if (gemm_op.can_implement(arguments) != cutlass::Status::kSuccess) {
+      std::cout << "Invalid Problem Size: "
+                << options.m << 'x' << options.n << 'x' << options.k << 'x' << options.l << std::endl;
+      return cutlass::Status::kErrorInvalidProblem;
+    }
+
+    CUTLASS_CHECK(gemm_op.initialize(arguments, workspace.get()));
+    CUTLASS_CHECK(gemm_op.run());
+    compat::wait();
+
+    if (options.verify != 0) {
+      bool passed = verify(problem_size, options);
+      std::cout << "Disposition: " << (passed ? "Passed" : "Failed") << std::endl;
+      if (!passed) {
+        return cutlass::Status::kErrorInternal;
+      }
+    }
+    else {
+      std::cout << "Disposition is skipped." << std::endl;
+    }
+
+    if (options.iterations > 0) {
+      GPU_Clock timer;
+      timer.start();
+      for (int i = 0; i < options.iterations; ++i) {
+        CUTLASS_CHECK(gemm_op.run());
+      }
+      compat::wait();
+
+      float elapsed = timer.seconds() / options.iterations;
+      double operations = (2.0 * options.m * options.n * options.k * options.l) * 1e-12;
+      std::cout << "Problem Size: "
+                << options.m << 'x' << options.n << 'x' << options.k << 'x' << options.l << std::endl;
+      printf("Cutlass GEMM Performance:     [%4.3f]TOPS    (%6.4f)ms\n",
+             operations / elapsed, elapsed * 1000);
+    }
+
+    return cutlass::Status::kSuccess;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+int main(int argc, const char** argv) {
+  Options options;
+  options.parse(argc, argv);
+
+  if (options.help) {
+    options.print_usage(std::cout) << std::endl;
+    return 0;
+  }
+
+  if (options.error) {
+    std::cerr << "Aborting execution." << std::endl;
+    return -1;
+  }
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.sm_count = cutlass::KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_BF16_C)
+  using ElementC = bfloat16_t;
+#else
+  using ElementC = float;
+#endif
+
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int4_t;
+  using ElementInputB = int4_t;
+  using ElementOutput = ElementC;
+
+  using LayoutA = cutlass::layout::RowMajor;
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PACKED_B)
+  using LayoutB = cutlass::layout::ColumnMajor;
+#else
+  using LayoutB = cutlass::layout::RowMajor;
+#endif
+  using LayoutC = cutlass::layout::RowMajor;
+  using LayoutD = cutlass::layout::RowMajor;
+
+  using GmemTiledCopyA = void;
+  using GmemTiledCopyB = void;
+  using TileShape = Shape<_256, _256, _64>;
+  using SubgroupLayout = Layout<Shape<_4, _8, _1>, Stride<_8, _1, _0>>;
+  using TiledMma = typename TiledMMAHelper<
+    MMA_Atom<XE_DPAS_TT<8, ElementAccumulator, ElementInputA, ElementInputB>>,
+    Layout<TileShape>,
+    SubgroupLayout>::TiledMMA;
+
+  constexpr int PipelineStages = 2;
+  using GEMMDispatchPolicy = cutlass::gemm::MainloopXeL1Staged<PipelineStages>;
+  using EpilogueDispatchPolicy = cutlass::epilogue::IntelXeGeneric;
+#if defined(CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A)
+  using EpilogueOp = cutlass::epilogue::fusion::BmgInt4DequantPerRowA<
+    ElementOutput, ElementComputeEpilogue, ElementC, ElementComputeEpilogue>;
+#else
+  using EpilogueOp = cutlass::epilogue::fusion::BmgInt4Dequant<
+    ElementOutput, ElementComputeEpilogue, ElementC, ElementComputeEpilogue>;
+#endif
+  using FusionCallbacks = cutlass::epilogue::fusion::FusionCallbacks<
+    EpilogueDispatchPolicy,
+    EpilogueOp,
+    TileShape,
+    decltype(tile_shape(TiledMma()))>;
+
+  using CollectiveEpilogue = cutlass::epilogue::collective::CollectiveEpilogue<
+    EpilogueDispatchPolicy,
+    TileShape,
+    void,
+    ElementC,
+    cutlass::gemm::TagToStrideC_t<LayoutC>,
+    ElementOutput,
+    cutlass::gemm::TagToStrideC_t<LayoutD>,
+    FusionCallbacks,
+    void,
+    void>;
+
+  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
+    GEMMDispatchPolicy,
+    TileShape,
+    ElementInputA,
+    cutlass::gemm::TagToStrideA_t<LayoutA>,
+    ElementInputB,
+    cutlass::gemm::TagToStrideB_t<LayoutB>,
+    TiledMma,
+    GmemTiledCopyA,
+    void,
+    void,
+    cute::identity,
+    GmemTiledCopyB,
+    void,
+    void,
+    cute::identity>;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+    Shape<int, int, int, int>,
+    CollectiveMainloop,
+    CollectiveEpilogue,
+    void>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  ExampleRunner<Gemm> runner;
+  CUTLASS_CHECK(runner.run(options, hw_info));
+  return 0;
+}

--- a/examples/00_bmg_gemm/00_bmg_gemm_int8_dequant.cpp
+++ b/examples/00_bmg_gemm/00_bmg_gemm_int8_dequant.cpp
@@ -1,0 +1,731 @@
+/***************************************************************************************************
+ * Copyright (C) 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+/*! \file
+    \brief BMG INT8 GEMM with epilogue dequantization.
+
+    The GEMM computes an int32 accumulator from int8 A and B.  The epilogue then
+    applies a per-tensor scale for A and a per-channel scale for B before adding
+    the C tensor:
+
+      D(m,n) = alpha * scale_a * scale_b(n) * acc(m,n) + beta * C(m,n)
+
+    The fp32 and bf16 C/D variants are built from this source file. The per-row-A
+    variants use an M-element scale_a vector instead of the scalar scale_a.
+*/
+
+#include "cutlass/epilogue/collective/xe_epilogue.hpp"
+#include "cutlass/epilogue/fusion/xe_callbacks.hpp"
+#include "cutlass/gemm/device/gemm_universal.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_mma.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+
+#include <cute/tensor.hpp>
+#include <random>
+#include <vector>
+
+#include "cutlass/util/command_line.h"
+#include "cutlass/util/device_memory.h"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/reference/device/gemm_complex.h"
+#include "cutlass/util/reference/device/tensor_compare.h"
+#include "sycl_common.hpp"
+#include "helper.h"
+
+using namespace cute;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::epilogue::fusion {
+
+template <
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementSource_ = ElementOutput_,
+  class ElementScalar_ = ElementCompute_,
+  int AlignmentScale_ = 128 / sizeof_bits_v<ElementScalar_>,
+  FloatRoundStyle RoundStyle_ = FloatRoundStyle::round_to_nearest
+>
+struct BmgInt8Dequant : FusionOperation {
+  using ElementOutput = ElementOutput_;
+  using ElementCompute = ElementCompute_;
+  using ElementSource = ElementSource_;
+  using ElementScalar = ElementScalar_;
+  static constexpr int AlignmentScalar = AlignmentScale_;
+  static constexpr bool IsSourceSupported = true;
+  static constexpr bool IsPerColScaleSupported = true;
+  static constexpr auto RoundStyle = RoundStyle_;
+};
+
+template <
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementSource_ = ElementOutput_,
+  class ElementScalar_ = ElementCompute_,
+  int AlignmentScale_ = 128 / sizeof_bits_v<ElementScalar_>,
+  FloatRoundStyle RoundStyle_ = FloatRoundStyle::round_to_nearest
+>
+struct BmgInt8DequantPerRowA : FusionOperation {
+  using ElementOutput = ElementOutput_;
+  using ElementCompute = ElementCompute_;
+  using ElementSource = ElementSource_;
+  using ElementScalar = ElementScalar_;
+  static constexpr int AlignmentScalar = AlignmentScale_;
+  static constexpr bool IsSourceSupported = true;
+  static constexpr bool IsPerRowScaleSupported = true;
+  static constexpr bool IsPerColScaleSupported = true;
+  static constexpr auto RoundStyle = RoundStyle_;
+};
+
+template <
+  class CtaTileShapeMNK,
+  class ElementOutput,
+  class ElementCompute,
+  class ElementSource,
+  class ElementScalar,
+  int AlignmentScale,
+  FloatRoundStyle RoundStyle
+>
+using BmgInt8DequantVisitor =
+  XeEVT<
+    XeCompute<homogeneous_multiply_add, ElementOutput, ElementCompute, RoundStyle>,
+    XeScalarBroadcast<ElementScalar, Stride<_0, _0, int64_t>>,
+    XeSrcFetch<ElementSource>,
+    XeEVT<
+      XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+      XeRowBroadcast<
+        0,
+        CtaTileShapeMNK,
+        ElementScalar,
+        ElementCompute,
+        Stride<_0, _1, int64_t>,
+        AlignmentScale>,
+      XeEVT<
+        XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+        XeScalarBroadcast<ElementScalar, Stride<_0, _0, int64_t>, 2>,
+        XeAccFetch
+      >
+    >
+  >;
+
+template <
+  class CtaTileShapeMNK,
+  class ElementOutput,
+  class ElementCompute,
+  class ElementSource,
+  class ElementScalar,
+  int AlignmentScale,
+  FloatRoundStyle RoundStyle
+>
+using BmgInt8DequantPerRowAVisitor =
+  XeEVT<
+    XeCompute<homogeneous_multiply_add, ElementOutput, ElementCompute, RoundStyle>,
+    XeScalarBroadcast<ElementScalar, Stride<_0, _0, int64_t>>,
+    XeSrcFetch<ElementSource>,
+    XeEVT<
+      XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+      XeColBroadcast<
+        0,
+        CtaTileShapeMNK,
+        ElementScalar,
+        ElementCompute,
+        Stride<_1, _0, int64_t>,
+        AlignmentScale>,
+      XeEVT<
+        XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+        XeRowBroadcast<
+          0,
+          CtaTileShapeMNK,
+          ElementScalar,
+          ElementCompute,
+          Stride<_0, _1, int64_t>,
+          AlignmentScale>,
+        XeEVT<
+          XeCompute<multiplies, ElementCompute, ElementCompute, RoundStyle>,
+          XeScalarBroadcast<ElementScalar, Stride<_0, _0, int64_t>>,
+          XeAccFetch
+        >
+      >
+    >
+  >;
+
+template <
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementSource_,
+  class ElementScalar_,
+  int AlignmentScale_,
+  FloatRoundStyle RoundStyle_,
+  class CtaTileShapeMNK_,
+  class EpilogueTile_
+>
+struct FusionCallbacks<
+    epilogue::IntelXeGeneric,
+    fusion::BmgInt8Dequant<
+      ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, AlignmentScale_, RoundStyle_>,
+    CtaTileShapeMNK_,
+    EpilogueTile_
+> : BmgInt8DequantVisitor<
+      CtaTileShapeMNK_,
+      typename cutlass::detail::get_unpacked_element_type<ElementOutput_>::type,
+      ElementCompute_,
+      ElementSource_,
+      ElementScalar_,
+      AlignmentScale_,
+      RoundStyle_
+    > {
+
+  using ElementOutput = ElementOutput_;
+  using ElementCompute = ElementCompute_;
+  using ElementSource = ElementSource_;
+  using ElementScalar = ElementScalar_;
+  using Operation = fusion::BmgInt8Dequant<
+    ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, AlignmentScale_, RoundStyle_>;
+  using Impl = BmgInt8DequantVisitor<
+    CtaTileShapeMNK_,
+    typename cutlass::detail::get_unpacked_element_type<ElementOutput_>::type,
+    ElementCompute_,
+    ElementSource_,
+    ElementScalar_,
+    AlignmentScale_,
+    RoundStyle_
+  >;
+
+  struct Arguments {
+    ElementScalar alpha = ElementScalar(1);
+    ElementScalar beta = ElementScalar(0);
+    ElementScalar scale_a = ElementScalar(1);
+    ElementScalar const* alpha_ptr = nullptr;
+    ElementScalar const* beta_ptr = nullptr;
+    ElementScalar const* scale_a_ptr = nullptr;
+
+    ElementScalar const* scale_b_ptr = nullptr;
+
+    using StrideAlpha = Stride<_0, _0, int64_t>;
+    using StrideBeta = Stride<_0, _0, int64_t>;
+    using StrideScaleB = Stride<_0, _1, int64_t>;
+
+    StrideAlpha dAlpha = {_0{}, _0{}, 0};
+    StrideBeta dBeta = {_0{}, _0{}, 0};
+    StrideAlpha dScaleA = {_0{}, _0{}, 0};
+    StrideScaleB dScaleB = {_0{}, _1{}, 0};
+
+    operator typename Impl::Arguments() const {
+      return {
+        {{beta}, {beta_ptr}, {dBeta}},
+        {},
+        {
+          {scale_b_ptr, ElementScalar(1), dScaleB},
+          {
+            {{scale_a, alpha}, {scale_a_ptr, alpha_ptr}, {dScaleA, dAlpha}},
+            {},
+            {}
+          },
+          {}
+        },
+        {}
+      };
+    }
+  };
+
+  using Impl::Impl;
+};
+
+template <
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementSource_,
+  class ElementScalar_,
+  int AlignmentScale_,
+  FloatRoundStyle RoundStyle_,
+  class CtaTileShapeMNK_,
+  class EpilogueTile_
+>
+struct FusionCallbacks<
+    epilogue::IntelXeGeneric,
+    fusion::BmgInt8DequantPerRowA<
+      ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, AlignmentScale_, RoundStyle_>,
+    CtaTileShapeMNK_,
+    EpilogueTile_
+> : BmgInt8DequantPerRowAVisitor<
+      CtaTileShapeMNK_,
+      typename cutlass::detail::get_unpacked_element_type<ElementOutput_>::type,
+      ElementCompute_,
+      ElementSource_,
+      ElementScalar_,
+      AlignmentScale_,
+      RoundStyle_
+    > {
+
+  using ElementOutput = ElementOutput_;
+  using ElementCompute = ElementCompute_;
+  using ElementSource = ElementSource_;
+  using ElementScalar = ElementScalar_;
+  using Operation = fusion::BmgInt8DequantPerRowA<
+    ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, AlignmentScale_, RoundStyle_>;
+  using Impl = BmgInt8DequantPerRowAVisitor<
+    CtaTileShapeMNK_,
+    typename cutlass::detail::get_unpacked_element_type<ElementOutput_>::type,
+    ElementCompute_,
+    ElementSource_,
+    ElementScalar_,
+    AlignmentScale_,
+    RoundStyle_
+  >;
+
+  struct Arguments {
+    ElementScalar alpha = ElementScalar(1);
+    ElementScalar beta = ElementScalar(0);
+    ElementScalar const* alpha_ptr = nullptr;
+    ElementScalar const* beta_ptr = nullptr;
+    ElementScalar const* scale_a_ptr = nullptr;
+    ElementScalar const* scale_b_ptr = nullptr;
+
+    using StrideAlpha = Stride<_0, _0, int64_t>;
+    using StrideBeta = Stride<_0, _0, int64_t>;
+    using StrideScaleA = Stride<_1, _0, int64_t>;
+    using StrideScaleB = Stride<_0, _1, int64_t>;
+
+    StrideAlpha dAlpha = {_0{}, _0{}, 0};
+    StrideBeta dBeta = {_0{}, _0{}, 0};
+    StrideScaleA dScaleA = {_1{}, _0{}, 0};
+    StrideScaleB dScaleB = {_0{}, _1{}, 0};
+
+    operator typename Impl::Arguments() const {
+      return {
+        {{beta}, {beta_ptr}, {dBeta}},
+        {},
+        {
+          {scale_a_ptr, ElementScalar(1), dScaleA},
+          {
+            {scale_b_ptr, ElementScalar(1), dScaleB},
+            {
+              {{alpha}, {alpha_ptr}, {dAlpha}},
+              {},
+              {}
+            },
+            {}
+          },
+          {}
+        },
+        {}
+      };
+    }
+  };
+
+  using Impl::Impl;
+};
+
+} // namespace cutlass::epilogue::fusion
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Options {
+  bool help;
+  bool error;
+
+  int m, n, k, l, iterations, verify;
+  float alpha, beta, scale_a;
+
+  Options()
+    : help(false),
+      error(false),
+      m(5120),
+      n(4096),
+      k(4096),
+      l(1),
+      iterations(100),
+      verify(1),
+      alpha(1.f),
+      beta(0.f),
+      scale_a(0.125f) {}
+
+  void parse(int argc, char const** args) {
+    cutlass::CommandLine cmd(argc, args);
+
+    if (cmd.check_cmd_line_flag("help")) {
+      help = true;
+      return;
+    }
+
+    cmd.get_cmd_line_argument("m", m, 5120);
+    cmd.get_cmd_line_argument("n", n, 4096);
+    cmd.get_cmd_line_argument("k", k, 4096);
+    cmd.get_cmd_line_argument("l", l, 1);
+    cmd.get_cmd_line_argument("alpha", alpha, 1.f);
+    cmd.get_cmd_line_argument("beta", beta, 0.f);
+    cmd.get_cmd_line_argument("scale-a", scale_a, 0.125f);
+    cmd.get_cmd_line_argument("iterations", iterations, 100);
+    cmd.get_cmd_line_argument("verify", verify, 1);
+  }
+
+  std::ostream& print_usage(std::ostream& out) const {
+    out << "BMG INT8 GEMM with epilogue dequantization\n\n"
+      << "Options:\n\n"
+      << "  --help                      If specified, displays this usage statement\n\n"
+      << "  --m=<int>                   Sets the M extent of the GEMM\n"
+      << "  --n=<int>                   Sets the N extent of the GEMM\n"
+      << "  --k=<int>                   Sets the K extent of the GEMM\n"
+      << "  --l=<int>                   Sets the L extent (batch count) of the GEMM\n"
+      << "  --alpha=<float>             Additional epilogue scale\n"
+      << "  --beta=<float>              Epilogue C scale\n"
+    #if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+      << "  --scale-a=<float>           Base value for the generated A per-row scales\n"
+    #else
+      << "  --scale-a=<float>           A per-tensor dequantization scale\n"
+    #endif
+      << "  --iterations=<int>          Iterations\n"
+      << "  --verify=<int>              Specify whether to verify\n\n";
+    return out;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class Gemm>
+struct ExampleRunner {
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using StrideD = typename Gemm::GemmKernel::StrideD;
+
+  using LayoutA = typename Gemm::LayoutA;
+  using LayoutB = typename Gemm::LayoutB;
+  using LayoutC = typename Gemm::LayoutC;
+  using LayoutD = typename Gemm::LayoutD;
+
+  using ElementA = typename Gemm::ElementA;
+  using ElementB = typename Gemm::ElementB;
+  using ElementAccumulator = typename Gemm::ElementAccumulator;
+  using CollectiveEpilogue = typename Gemm::CollectiveEpilogue;
+  using ElementC = typename Gemm::ElementC;
+  using ElementOutput = typename CollectiveEpilogue::ElementOutput;
+  using ElementCompute = typename CollectiveEpilogue::ElementCompute;
+  using ProblemShapeType = typename Gemm::GemmKernel::ProblemShape;
+
+  using ElementScale = float;
+  using StrideScaleB = typename CollectiveEpilogue::FusionCallbacks::Arguments::StrideScaleB;
+#if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+  using StrideScaleA = typename CollectiveEpilogue::FusionCallbacks::Arguments::StrideScaleA;
+#endif
+
+  StrideA stride_A;
+  StrideB stride_B;
+  StrideC stride_C;
+  StrideD stride_D;
+  uint64_t seed = 0;
+
+  cutlass::DeviceAllocation<ElementA> block_A;
+  cutlass::DeviceAllocation<ElementB> block_B;
+  cutlass::DeviceAllocation<ElementC> block_C;
+  cutlass::DeviceAllocation<ElementScale> block_scale_B;
+#if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+  cutlass::DeviceAllocation<ElementScale> block_scale_A;
+#endif
+  cutlass::DeviceAllocation<ElementOutput> block_D;
+  cutlass::DeviceAllocation<ElementAccumulator> block_ref_accum;
+  cutlass::DeviceAllocation<ElementOutput> block_ref_D;
+
+  std::vector<ElementA> host_A;
+  std::vector<ElementB> host_B;
+  std::vector<ElementC> host_C;
+  std::vector<ElementScale> host_scale_B;
+#if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+  std::vector<ElementScale> host_scale_A;
+#endif
+
+  void initialize(const ProblemShapeType& problem_size, float scale_a) {
+    auto problem_shape_MNKL = cute::append<4>(problem_size, 1);
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    stride_A = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, L));
+    stride_B = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N, K, L));
+    stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(M, N, L));
+    stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N, L));
+
+    std::size_t elements_A = static_cast<std::size_t>(M) * K * L;
+    std::size_t elements_B = static_cast<std::size_t>(K) * N * L;
+    std::size_t elements_C = static_cast<std::size_t>(M) * N * L;
+
+    block_A.reset(elements_A);
+    block_B.reset(elements_B);
+    block_C.reset(elements_C);
+    block_scale_B.reset(static_cast<std::size_t>(N));
+  #if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+    block_scale_A.reset(static_cast<std::size_t>(M));
+  #endif
+    block_D.reset(elements_C);
+    block_ref_accum.reset(elements_C);
+    block_ref_D.reset(elements_C);
+
+    host_A.resize(elements_A);
+    host_B.resize(elements_B);
+    host_C.resize(elements_C);
+    host_scale_B.resize(static_cast<std::size_t>(N));
+  #if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+    host_scale_A.resize(static_cast<std::size_t>(M));
+  #endif
+
+    std::mt19937 rng(static_cast<std::mt19937::result_type>(seed));
+    std::uniform_int_distribution<int> quantized_distribution(-8, 8);
+    std::uniform_real_distribution<float> c_distribution(-1.f, 1.f);
+
+    for (auto& value : host_A) {
+      value = static_cast<ElementA>(quantized_distribution(rng));
+    }
+    for (auto& value : host_B) {
+      value = static_cast<ElementB>(quantized_distribution(rng));
+    }
+    for (auto& value : host_C) {
+      value = static_cast<ElementC>(c_distribution(rng));
+    }
+    for (int n = 0; n < N; ++n) {
+      host_scale_B[n] = 0.015625f * static_cast<float>(1 + (n % 7));
+    }
+#if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+    for (int m = 0; m < M; ++m) {
+      host_scale_A[m] = scale_a * (0.5f + 0.125f * static_cast<float>(m % 5));
+    }
+#endif
+
+    block_A.copy_from_host(host_A.data());
+    block_B.copy_from_host(host_B.data());
+    block_C.copy_from_host(host_C.data());
+    block_scale_B.copy_from_host(host_scale_B.data());
+#if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+    block_scale_A.copy_from_host(host_scale_A.data());
+#endif
+  }
+
+  bool verify(const ProblemShapeType& problem_size, const Options& options) {
+    auto [M, N, K, L] = problem_size;
+
+    cutlass::TensorRef ref_A(block_A.get(), LayoutA::packed({M, K}));
+    cutlass::TensorRef ref_B(block_B.get(), LayoutB::packed({K, N}));
+    cutlass::TensorRef ref_C(block_C.get(), LayoutC::packed({M, N}));
+    cutlass::TensorRef ref_accum(block_ref_accum.get(), LayoutD::packed({M, N}));
+
+    cutlass::reference::device::GemmComplex(
+      {M, N, K},
+      ElementCompute(1),
+      ref_A,
+      cutlass::ComplexTransform::kNone,
+      ref_B,
+      cutlass::ComplexTransform::kNone,
+      ElementCompute(0),
+      ref_C,
+      ref_accum,
+      ElementAccumulator(0),
+      L,
+      M * K,
+      K * N,
+      M * N,
+      M * N);
+
+    compat::wait();
+
+    std::size_t elements_D = static_cast<std::size_t>(M) * N * L;
+    std::vector<ElementAccumulator> host_accum(elements_D);
+    std::vector<ElementOutput> host_expected(elements_D);
+    cutlass::device_memory::copy_to_host(host_accum.data(), block_ref_accum.get(), elements_D);
+
+    for (int l = 0; l < L; ++l) {
+      for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+          std::size_t index =
+            (static_cast<std::size_t>(l) * M + m) * N + n;
+          float scale_a = options.scale_a;
+#if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+          scale_a = host_scale_A[m];
+#endif
+          float value =
+            options.alpha * scale_a * host_scale_B[n] * static_cast<float>(host_accum[index]);
+          value += options.beta * static_cast<float>(host_C[index]);
+          host_expected[index] = static_cast<ElementOutput>(value);
+        }
+      }
+    }
+
+    block_ref_D.copy_from_host(host_expected.data());
+    compat::wait();
+
+    ElementOutput epsilon(1e-2f);
+    ElementOutput non_zero_floor(1e-4f);
+    bool passed = cutlass::reference::device::BlockCompareRelativelyEqual(
+      block_ref_D.get(), block_D.get(), block_D.size(), epsilon, non_zero_floor);
+
+    return passed;
+  }
+
+  cutlass::Status run(const Options& options, const cutlass::KernelHardwareInfo& hw_info) {
+    ProblemShapeType problem_size = {options.m, options.n, options.k, options.l};
+    initialize(problem_size, options.scale_a);
+
+    typename Gemm::GemmKernel::EpilogueArguments epilogue_arguments{
+      {}, block_C.get(), stride_C, block_D.get(), stride_D};
+    epilogue_arguments.thread.alpha = static_cast<ElementCompute>(options.alpha);
+    epilogue_arguments.thread.beta = static_cast<ElementCompute>(options.beta);
+  #if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+    epilogue_arguments.thread.scale_a_ptr = block_scale_A.get();
+    epilogue_arguments.thread.dScaleA = StrideScaleA{};
+  #else
+    epilogue_arguments.thread.scale_a = static_cast<ElementCompute>(options.scale_a);
+  #endif
+    epilogue_arguments.thread.scale_b_ptr = block_scale_B.get();
+    epilogue_arguments.thread.dScaleB = StrideScaleB{};
+
+    typename Gemm::GemmKernel::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      problem_size,
+      {block_A.get(), stride_A, block_B.get(), stride_B},
+      epilogue_arguments,
+      hw_info};
+
+    Gemm gemm_op;
+    std::size_t workspace_size = Gemm::get_workspace_size(arguments);
+    cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+    if (gemm_op.can_implement(arguments) != cutlass::Status::kSuccess) {
+      std::cout << "Invalid Problem Size: "
+                << options.m << 'x' << options.n << 'x' << options.k << 'x' << options.l << std::endl;
+      return cutlass::Status::kErrorInvalidProblem;
+    }
+
+    CUTLASS_CHECK(gemm_op.initialize(arguments, workspace.get()));
+    CUTLASS_CHECK(gemm_op.run());
+    compat::wait();
+
+    if (options.verify != 0) {
+      bool passed = verify(problem_size, options);
+      std::cout << "Disposition: " << (passed ? "Passed" : "Failed") << std::endl;
+      if (!passed) {
+        return cutlass::Status::kErrorInternal;
+      }
+    }
+    else {
+      std::cout << "Disposition is skipped." << std::endl;
+    }
+
+    if (options.iterations > 0) {
+      GPU_Clock timer;
+      timer.start();
+      for (int i = 0; i < options.iterations; ++i) {
+        CUTLASS_CHECK(gemm_op.run());
+      }
+      compat::wait();
+
+      float elapsed = timer.seconds() / options.iterations;
+      double operations = (2.0 * options.m * options.n * options.k * options.l) * 1e-12;
+      std::cout << "Problem Size: "
+                << options.m << 'x' << options.n << 'x' << options.k << 'x' << options.l << std::endl;
+      printf("Cutlass GEMM Performance:     [%4.3f]TOPS    (%6.4f)ms\n",
+             operations / elapsed, elapsed * 1000);
+    }
+
+    return cutlass::Status::kSuccess;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+int main(int argc, const char** argv) {
+  Options options;
+  options.parse(argc, argv);
+
+  if (options.help) {
+    options.print_usage(std::cout) << std::endl;
+    return 0;
+  }
+
+  if (options.error) {
+    std::cerr << "Aborting execution." << std::endl;
+    return -1;
+  }
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.sm_count = cutlass::KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+
+#if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_BF16_C)
+  using ElementC = bfloat16_t;
+#else
+  using ElementC = float;
+#endif
+
+  using ElementAccumulator = int32_t;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = int8_t;
+  using ElementInputB = int8_t;
+  using ElementOutput = ElementC;
+
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+  using LayoutD = cutlass::layout::RowMajor;
+
+  using GmemTiledCopyA = void;
+  using GmemTiledCopyB = void;
+  using TileShape = Shape<_256, _256, _64>;
+  using SubgroupLayout = Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>;
+  using TiledMma = typename TiledMMAHelper<
+    MMA_Atom<XE_DPAS_TT<8, ElementAccumulator, ElementInputA, ElementInputB>>,
+    Layout<TileShape>,
+    SubgroupLayout>::TiledMMA;
+
+  constexpr int PipelineStages = 2;
+  using GEMMDispatchPolicy = cutlass::gemm::MainloopXeL1Staged<PipelineStages>;
+  using EpilogueDispatchPolicy = cutlass::epilogue::IntelXeGeneric;
+#if defined(CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A)
+  using EpilogueOp = cutlass::epilogue::fusion::BmgInt8DequantPerRowA<
+    ElementOutput, ElementComputeEpilogue, ElementC, ElementComputeEpilogue>;
+#else
+  using EpilogueOp = cutlass::epilogue::fusion::BmgInt8Dequant<
+    ElementOutput, ElementComputeEpilogue, ElementC, ElementComputeEpilogue>;
+#endif
+  using FusionCallbacks = cutlass::epilogue::fusion::FusionCallbacks<
+    EpilogueDispatchPolicy,
+    EpilogueOp,
+    TileShape,
+    decltype(tile_shape(TiledMma()))>;
+
+  using CollectiveEpilogue = cutlass::epilogue::collective::CollectiveEpilogue<
+    EpilogueDispatchPolicy,
+    TileShape,
+    void,
+    ElementC,
+    cutlass::gemm::TagToStrideC_t<LayoutC>,
+    ElementOutput,
+    cutlass::gemm::TagToStrideC_t<LayoutD>,
+    FusionCallbacks,
+    void,
+    void>;
+
+  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
+    GEMMDispatchPolicy,
+    TileShape,
+    ElementInputA,
+    cutlass::gemm::TagToStrideA_t<LayoutA>,
+    ElementInputB,
+    cutlass::gemm::TagToStrideB_t<LayoutB>,
+    TiledMma,
+    GmemTiledCopyA,
+    void,
+    void,
+    cute::identity,
+    GmemTiledCopyB,
+    void,
+    void,
+    cute::identity>;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+    Shape<int, int, int, int>,
+    CollectiveMainloop,
+    CollectiveEpilogue,
+    void>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  ExampleRunner<Gemm> runner;
+  CUTLASS_CHECK(runner.run(options, hw_info));
+  return 0;
+}

--- a/examples/00_bmg_gemm/CMakeLists.txt
+++ b/examples/00_bmg_gemm/CMakeLists.txt
@@ -123,6 +123,90 @@ target_compile_definitions(00_bmg_gemm_int8_dequant_per_row_a_bf16 PRIVATE
   CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A=1
 )
 
+set(TEST_INT4_DEQUANT "--m=512 --n=512 --k=512 --l=2 --iterations=20 --verify=1")
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_dequant_fp32
+  00_bmg_gemm_int4_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_DEQUANT
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_dequant_bf16
+  00_bmg_gemm_int4_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int4_dequant_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_BF16_C=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_dequant_per_row_a_fp32
+  00_bmg_gemm_int4_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int4_dequant_per_row_a_fp32 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_dequant_per_row_a_bf16
+  00_bmg_gemm_int4_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int4_dequant_per_row_a_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_BF16_C=1
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_dequant_packed_b_fp32
+  00_bmg_gemm_int4_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int4_dequant_packed_b_fp32 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_PACKED_B=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_dequant_packed_b_bf16
+  00_bmg_gemm_int4_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int4_dequant_packed_b_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_BF16_C=1
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_PACKED_B=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_dequant_packed_b_per_row_a_fp32
+  00_bmg_gemm_int4_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int4_dequant_packed_b_per_row_a_fp32 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_PACKED_B=1
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_dequant_packed_b_per_row_a_bf16
+  00_bmg_gemm_int4_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int4_dequant_packed_b_per_row_a_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_BF16_C=1
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_PACKED_B=1
+  CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A=1
+)
+
 cutlass_example_add_executable(
   00_bmg_gemm_padded
   00_bmg_gemm_padded.cpp

--- a/examples/00_bmg_gemm/CMakeLists.txt
+++ b/examples/00_bmg_gemm/CMakeLists.txt
@@ -50,6 +50,39 @@ cutlass_example_add_executable(
   ${GEMM_ARGS}
 )
 
+if (CUTLASS_TEST_FOR_CRI)
+  set(TEST_INTEGER_GEMM "--m=${CRI_GEMM_DEFAULT_SIZE} --n=${CRI_GEMM_DEFAULT_SIZE} --k=${CRI_GEMM_DEFAULT_SIZE} --l=1 --iterations=${CRI_DEFAULT_ITERATIONS} --verify=${CRI_DEFAULT_VERIFY}")
+else()
+  set(TEST_INTEGER_GEMM "--m=512 --n=512 --k=512 --l=2 --iterations=20 --verify=1")
+endif()
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int8
+  00_bmg_gemm.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INTEGER_GEMM
+)
+target_compile_definitions(00_bmg_gemm_int8 PRIVATE CUTLASS_BMG_GEMM_INT8=1)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4
+  00_bmg_gemm.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INTEGER_GEMM
+)
+target_compile_definitions(00_bmg_gemm_int4 PRIVATE CUTLASS_BMG_GEMM_INT4=1)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_packed_b
+  00_bmg_gemm.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INTEGER_GEMM
+)
+target_compile_definitions(00_bmg_gemm_int4_packed_b PRIVATE
+  CUTLASS_BMG_GEMM_INT4=1
+  CUTLASS_BMG_GEMM_INT4_PACKED_B=1
+)
+
 cutlass_example_add_executable(
   00_bmg_gemm_padded
   00_bmg_gemm_padded.cpp

--- a/examples/00_bmg_gemm/CMakeLists.txt
+++ b/examples/00_bmg_gemm/CMakeLists.txt
@@ -207,6 +207,90 @@ target_compile_definitions(00_bmg_gemm_int4_dequant_packed_b_per_row_a_bf16 PRIV
   CUTLASS_BMG_GEMM_INT4_DEQUANT_PER_ROW_A=1
 )
 
+set(TEST_INT4_BLOCK_SCALED "--m=512 --n=512 --k=512 --l=2 --iterations=20 --verify=1")
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_block_scaled_128_packed_b_fp32
+  00_bmg_gemm_int4_block_scaled.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_BLOCK_SCALED
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_block_scaled_128_packed_b_bf16
+  00_bmg_gemm_int4_block_scaled.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_BLOCK_SCALED
+)
+target_compile_definitions(00_bmg_gemm_int4_block_scaled_128_packed_b_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_BLOCK_SCALED_BF16=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_block_scaled_256_packed_b_fp32
+  00_bmg_gemm_int4_block_scaled.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_BLOCK_SCALED
+)
+target_compile_definitions(00_bmg_gemm_int4_block_scaled_256_packed_b_fp32 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_BLOCK_SCALED_256=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int4_block_scaled_256_packed_b_bf16
+  00_bmg_gemm_int4_block_scaled.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_BLOCK_SCALED
+)
+target_compile_definitions(00_bmg_gemm_int4_block_scaled_256_packed_b_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT4_BLOCK_SCALED_256=1
+  CUTLASS_BMG_GEMM_INT4_BLOCK_SCALED_BF16=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int8_block_scaled_128_packed_b_fp32
+  00_bmg_gemm_int4_block_scaled.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_BLOCK_SCALED
+)
+target_compile_definitions(00_bmg_gemm_int8_block_scaled_128_packed_b_fp32 PRIVATE
+  CUTLASS_BMG_GEMM_INT8_BLOCK_SCALED=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int8_block_scaled_128_packed_b_bf16
+  00_bmg_gemm_int4_block_scaled.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_BLOCK_SCALED
+)
+target_compile_definitions(00_bmg_gemm_int8_block_scaled_128_packed_b_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT8_BLOCK_SCALED=1
+  CUTLASS_BMG_GEMM_BLOCK_SCALED_BF16=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int8_block_scaled_256_packed_b_fp32
+  00_bmg_gemm_int4_block_scaled.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_BLOCK_SCALED
+)
+target_compile_definitions(00_bmg_gemm_int8_block_scaled_256_packed_b_fp32 PRIVATE
+  CUTLASS_BMG_GEMM_INT8_BLOCK_SCALED=1
+  CUTLASS_BMG_GEMM_BLOCK_SCALED_256=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int8_block_scaled_256_packed_b_bf16
+  00_bmg_gemm_int4_block_scaled.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT4_BLOCK_SCALED
+)
+target_compile_definitions(00_bmg_gemm_int8_block_scaled_256_packed_b_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT8_BLOCK_SCALED=1
+  CUTLASS_BMG_GEMM_BLOCK_SCALED_256=1
+  CUTLASS_BMG_GEMM_BLOCK_SCALED_BF16=1
+)
+
 cutlass_example_add_executable(
   00_bmg_gemm_padded
   00_bmg_gemm_padded.cpp

--- a/examples/00_bmg_gemm/CMakeLists.txt
+++ b/examples/00_bmg_gemm/CMakeLists.txt
@@ -83,6 +83,46 @@ target_compile_definitions(00_bmg_gemm_int4_packed_b PRIVATE
   CUTLASS_BMG_GEMM_INT4_PACKED_B=1
 )
 
+set(TEST_INT8_DEQUANT "--m=512 --n=512 --k=512 --l=2 --iterations=20 --verify=1")
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int8_dequant_fp32
+  00_bmg_gemm_int8_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT8_DEQUANT
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int8_dequant_bf16
+  00_bmg_gemm_int8_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT8_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int8_dequant_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT8_DEQUANT_BF16_C=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int8_dequant_per_row_a_fp32
+  00_bmg_gemm_int8_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT8_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int8_dequant_per_row_a_fp32 PRIVATE
+  CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A=1
+)
+
+cutlass_example_add_executable(
+  00_bmg_gemm_int8_dequant_per_row_a_bf16
+  00_bmg_gemm_int8_dequant.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_INT8_DEQUANT
+)
+target_compile_definitions(00_bmg_gemm_int8_dequant_per_row_a_bf16 PRIVATE
+  CUTLASS_BMG_GEMM_INT8_DEQUANT_BF16_C=1
+  CUTLASS_BMG_GEMM_INT8_DEQUANT_PER_ROW_A=1
+)
+
 cutlass_example_add_executable(
   00_bmg_gemm_padded
   00_bmg_gemm_padded.cpp

--- a/include/cute/arch/mma_xe.hpp
+++ b/include/cute/arch/mma_xe.hpp
@@ -299,6 +299,23 @@ CUTE_DECLARE_XE_DPAS_TT(d,   s4,   s8,   d)
 
 #endif
 
+template <int M, typename TypeA, typename TypeB = TypeA>
+struct XE_DPAS_TT_INT_BLOCK_SCALED
+  : XE_DPAS_TT<M, dpas_type::d, TypeA, TypeB, dpas_type::d> {
+  static_assert(
+    (std::is_same_v<TypeA, dpas_type::s4> && std::is_same_v<TypeB, dpas_type::s4>) ||
+    (std::is_same_v<TypeA, dpas_type::s8> && std::is_same_v<TypeB, dpas_type::s8>),
+    "Integer block-scaled DPAS supports signed INT4xINT4 or INT8xINT8.");
+};
+
+template <int M>
+using XE_DPAS_TT_INT4_BLOCK_SCALED =
+    XE_DPAS_TT_INT_BLOCK_SCALED<M, dpas_type::s4>;
+
+template <int M>
+using XE_DPAS_TT_INT8_BLOCK_SCALED =
+    XE_DPAS_TT_INT_BLOCK_SCALED<M, dpas_type::s8>;
+
 #undef CUTE_DECLARE_XE_DPAS_TT
 #undef CUTE_DECLARE_XE_BDPAS_TT
 

--- a/include/cute/atom/mma_traits_xe.hpp
+++ b/include/cute/atom/mma_traits_xe.hpp
@@ -220,4 +220,79 @@ struct MMA_Traits<XE_BDPAS_TT<M, TD, TA, TB, TC>> : public MMA_Traits<XE_DPAS_TT
 
 };
 
+template <int M, typename TypeA, typename TypeB>
+struct MMA_Traits<XE_DPAS_TT_INT_BLOCK_SCALED<M, TypeA, TypeB>>
+{
+  using MMAOp = XE_DPAS_TT_INT_BLOCK_SCALED<M, TypeA, TypeB>;
+  using RawOp = XE_DPAS_TT<M, dpas_type::d, TypeA, TypeB, dpas_type::d>;
+  using RawTraits = MMA_Traits<RawOp>;
+
+  static_assert(
+    (std::is_same_v<TypeA, dpas_type::s4> && std::is_same_v<TypeB, dpas_type::s4>) ||
+    (std::is_same_v<TypeA, dpas_type::s8> && std::is_same_v<TypeB, dpas_type::s8>),
+    "Integer block-scaled DPAS traits support signed INT4xINT4 or INT8xINT8.");
+
+  using ValTypeD = float;
+  using ValTypeA = typename RawTraits::ValTypeA;
+  using ValTypeB = typename RawTraits::ValTypeB;
+  using ValTypeC = float;
+
+  using FrgTypeD = float;
+  using FrgTypeC = float;
+
+  using Shape_MNK = typename RawTraits::Shape_MNK;
+  using ThrID = typename RawTraits::ThrID;
+  using ALayout = typename RawTraits::ALayout;
+  using BLayout = typename RawTraits::BLayout;
+  using CLayout = typename RawTraits::CLayout;
+
+  template <bool NoAcc = false,
+            class TD1, class DLayout,
+            class TA1, class ALayout1,
+            class TB1, class BLayout1,
+            class TC1, class CLayout1>
+  CUTE_DEVICE friend void
+  mma_unpack(MMA_Traits const&,
+             Tensor<TD1, DLayout>      & D,
+             Tensor<TA1, ALayout1> const& A,
+             Tensor<TB1, BLayout1> const& B,
+             Tensor<TC1, CLayout1> const& C)
+  {
+    using RegTypeD = typename remove_extent<typename RawOp::DRegisters>::type;
+    using RegTypeA = typename remove_extent<typename RawOp::ARegisters>::type;
+    using RegTypeB = typename remove_extent<typename RawOp::BRegisters>::type;
+    using RegTypeC = typename remove_extent<typename RawOp::CRegisters>::type;
+
+    using DValue = typename Tensor<TD1, DLayout>::value_type;
+    using CValue = typename Tensor<TC1, CLayout1>::value_type;
+
+    if constexpr (is_same_v<DValue, int32_t> && is_same_v<CValue, int32_t>) {
+      Tensor rA = recast<RegTypeA>(A);
+      Tensor rB = recast<RegTypeB>(B);
+      Tensor rD = recast<RegTypeD>(D);
+      Tensor rC = recast<RegTypeC>(C);
+      cute::detail::explode_mma<RawOp, NoAcc>(
+          rD, make_int_sequence<extent<typename RawOp::DRegisters>::value>{},
+          rA, make_int_sequence<extent<typename RawOp::ARegisters>::value>{},
+          rB, make_int_sequence<extent<typename RawOp::BRegisters>::value>{},
+          rC, make_int_sequence<extent<typename RawOp::CRegisters>::value>{});
+    }
+    else {
+      Tensor rA = recast<RegTypeA>(A);
+      Tensor rB = recast<RegTypeB>(B);
+      RegTypeD product{};
+      RegTypeC zero{};
+      RawOp::template fma<true>(product, rA[0], rB[0], zero);
+
+      for (int i = 0; i < M; ++i) {
+        float value = static_cast<float>(product[i]);
+        if constexpr (!NoAcc) {
+          value += static_cast<float>(C(i));
+        }
+        D(i) = static_cast<DValue>(value);
+      }
+    }
+  }
+};
+
 } /* namespace cute */

--- a/include/cutlass/gemm/collective/collective_mma.hpp
+++ b/include/cutlass/gemm/collective/collective_mma.hpp
@@ -94,6 +94,7 @@
 #include "cutlass/gemm/collective/xe_array_mma_blockscaled_mxfp.hpp"
 #include "cutlass/gemm/collective/xe_mma_blockscaled_fp8.hpp"
 #include "cutlass/gemm/collective/xe_array_mma_blockscaled_fp8.hpp"
+#include "cutlass/gemm/collective/xe_mma_int4_blockscaled.hpp"
 #endif
 
 #if defined(CUTLASS_ENABLE_SYCL)

--- a/include/cutlass/gemm/collective/xe_mma_int4_blockscaled.hpp
+++ b/include/cutlass/gemm/collective/xe_mma_int4_blockscaled.hpp
@@ -1,0 +1,380 @@
+/***************************************************************************************************
+ * Copyright (C) 2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+
+#include "cute/algorithm/functional.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cute/algorithm/gemm.hpp"
+
+namespace cutlass::gemm::collective {
+using namespace cute;
+
+template <
+  int Stages,
+  int GroupK_,
+  class KernelSchedule,
+  class TileShape_,
+  class ElementPairA_,
+  class StridePairA_,
+  class ElementPairB_,
+  class StridePairB_,
+  class TiledMma_,
+  class GmemTiledCopyPairA_,
+  class SmemLayoutAtomA_,
+  class SmemCopyAtomA_,
+  class TransformA_,
+  class GmemTiledCopyPairB_,
+  class SmemLayoutAtomB_,
+  class SmemCopyAtomB_,
+  class TransformB_>
+struct CollectiveMma<
+  MainloopIntelXeXMX16IntBlockScaled<Stages, GroupK_, KernelSchedule>,
+  TileShape_,
+  ElementPairA_,
+  StridePairA_,
+  ElementPairB_,
+  StridePairB_,
+  TiledMma_,
+  GmemTiledCopyPairA_,
+  SmemLayoutAtomA_,
+  SmemCopyAtomA_,
+  TransformA_,
+  GmemTiledCopyPairB_,
+  SmemLayoutAtomB_,
+  SmemCopyAtomB_,
+  TransformB_>
+{
+public:
+  using DispatchPolicy = MainloopIntelXeXMX16IntBlockScaled<Stages, GroupK_, KernelSchedule>;
+  using WorkgroupTileShape = TileShape_;
+  using TiledMma = TiledMma_;
+
+  using ElementPairA = ElementPairA_;
+  using ElementPairB = ElementPairB_;
+  using StridePairA = StridePairA_;
+  using StridePairB = StridePairB_;
+
+  using ElementA = remove_cvref_t<decltype(get<0>(ElementPairA{}))>;
+  using ElementB = remove_cvref_t<decltype(get<0>(ElementPairB{}))>;
+  using ElementScaleA = remove_cvref_t<decltype(get<1>(ElementPairA{}))>;
+  using ElementScaleB = remove_cvref_t<decltype(get<1>(ElementPairB{}))>;
+
+  using StrideA = remove_pointer_t<remove_cvref_t<decltype(get<0>(StridePairA{}))>>;
+  using StrideB = remove_pointer_t<remove_cvref_t<decltype(get<0>(StridePairB{}))>>;
+  using StrideScaleA = remove_pointer_t<remove_cvref_t<decltype(get<1>(StridePairA{}))>>;
+  using StrideScaleB = remove_pointer_t<remove_cvref_t<decltype(get<1>(StridePairB{}))>>;
+
+  using GmemTiledCopyA = typename std::tuple_element<0, GmemTiledCopyPairA_>::type;
+  using GmemTiledCopyB = typename std::tuple_element<0, GmemTiledCopyPairB_>::type;
+  using SmemLayoutAtomA = SmemLayoutAtomA_;
+  using SmemLayoutAtomB = SmemLayoutAtomB_;
+  using SmemCopyAtomA = SmemCopyAtomA_;
+  using SmemCopyAtomB = SmemCopyAtomB_;
+  using TransformA = TransformA_;
+  using TransformB = TransformB_;
+  using ArchTag = typename DispatchPolicy::ArchTag;
+  using ElementAccumulator = float;
+
+  static constexpr int SubgroupSize = DispatchPolicy::SubgroupSize;
+  using MmaAtomShape = typename TiledMma::AtomShape_MNK;
+
+  static constexpr int GroupK = GroupK_;
+  static constexpr int BLK_M = get<0>(WorkgroupTileShape{});
+  static constexpr int BLK_N = get<1>(WorkgroupTileShape{});
+  static constexpr int BLK_K = get<2>(WorkgroupTileShape{});
+  static constexpr int ATOM_M = get<0>(MmaAtomShape{});
+  static constexpr int ATOM_N = get<1>(MmaAtomShape{});
+  static constexpr int ATOM_K = get<2>(MmaAtomShape{});
+  static constexpr int SG_NUMS_M = get<1>(typename TiledMma::ThrLayoutVMNK{}.shape());
+  static constexpr int SG_NUMS_N = get<2>(typename TiledMma::ThrLayoutVMNK{}.shape());
+  static constexpr int SG_M = ceil_div(BLK_M, SG_NUMS_M);
+  static constexpr int SG_N = ceil_div(BLK_N, SG_NUMS_N);
+  static constexpr int M_ITERS = SG_M / ATOM_M;
+  static constexpr int N_ITERS = SG_N / ATOM_N;
+  static constexpr int ScaleAChunks = cute::ceil_div(SG_M, SubgroupSize);
+  using SubgroupTileShape = Shape<C<SG_M>, C<SG_N>, C<ceil_div(BLK_K, ATOM_K)>>;
+
+  static constexpr auto Num_SGs = SG_NUMS_M * SG_NUMS_N;
+  static constexpr uint32_t MaxThreadsPerBlock = size(TiledMma{});
+
+  static_assert(std::is_same_v<TransformA, cute::identity>, "Transformation for A is not supported.");
+  static_assert(std::is_same_v<TransformB, cute::identity>, "Transformation for B is not supported.");
+  static_assert(GroupK == 128 || GroupK == 256, "Integer block scaling supports K blocks of 128 or 256.");
+  static_assert(GroupK % BLK_K == 0, "The block scale K size must be divisible by the workgroup K tile.");
+  static_assert(BLK_K % ATOM_K == 0, "The workgroup K tile must be divisible by the DPAS K tile.");
+  static_assert(
+    std::is_same_v<typename TiledMma::ValTypeA, int4_t> ||
+    std::is_same_v<typename TiledMma::ValTypeA, int8_t>,
+    "A must use signed INT4 or INT8.");
+  static_assert(
+    std::is_same_v<typename TiledMma::ValTypeB, int4_t> ||
+    std::is_same_v<typename TiledMma::ValTypeB, int8_t>,
+    "B must use signed INT4 or INT8.");
+  static_assert(std::is_same_v<typename TiledMma::ValTypeA, typename TiledMma::ValTypeB>,
+                "A and B must use the same signed integer type.");
+
+  template<class Element, class Stride>
+  using TensorType = decltype(make_tensor(
+      make_gmem_ptr(static_cast<Element const*>(nullptr)),
+      make_layout(make_shape(int{}, int{}, int{}), Stride{})));
+
+  struct Arguments {
+    ElementA const* ptr_A;
+    StrideA dA;
+    ElementB const* ptr_B;
+    StrideB dB;
+    ElementScaleA const* ptr_SA;
+    StrideScaleA dSA;
+    ElementScaleB const* ptr_SB;
+    StrideScaleB dSB;
+  };
+
+  struct Params {
+    TensorType<ElementA, StrideA> mA_mkl;
+    TensorType<ElementB, StrideB> mB_nkl;
+    TensorType<ElementScaleA, StrideScaleA> mAscale;
+    TensorType<ElementScaleB, StrideScaleB> mBscale;
+  };
+
+  CollectiveMma() = default;
+
+  template <class ProblemShape>
+  static constexpr Params
+  to_underlying_arguments(ProblemShape const& problem_shape, Arguments const& args, void* workspace) {
+    (void)workspace;
+    auto [M, N, K, L] = problem_shape;
+    auto scale_k = cute::ceil_div(K, GroupK);
+
+    return {
+      make_tensor(make_gmem_ptr(args.ptr_A), make_layout(make_shape(M, K, L), args.dA)),
+      make_tensor(make_gmem_ptr(args.ptr_B), make_layout(make_shape(N, K, L), args.dB)),
+      make_tensor(make_gmem_ptr(args.ptr_SA), make_layout(make_shape(M, scale_k, L), args.dSA)),
+      make_tensor(make_gmem_ptr(args.ptr_SB), make_layout(make_shape(N, scale_k, L), args.dSB))
+    };
+  }
+
+  template <class ProblemShape>
+  static bool
+  can_implement(ProblemShape problem_shapes, Arguments const& args) {
+    constexpr int copy_alignment_bits = 128;
+    constexpr int batch_alignment_bits = 512;
+    auto problem_shape_MNKL = append<4>(problem_shapes, 1);
+    auto [M, N, K, L] = problem_shape_MNKL;
+    bool implementable = true;
+
+    implementable &= (K % GroupK == 0);
+    implementable &= (K % BLK_K == 0);
+
+    constexpr int min_aligned_elements_A = copy_alignment_bits / sizeof_bits<ElementA>::value;
+    constexpr int min_aligned_elements_B = copy_alignment_bits / sizeof_bits<ElementB>::value;
+    implementable &= cutlass::detail::check_alignment<min_aligned_elements_A>(make_shape(1, K, L), args.dA);
+    implementable &= cutlass::detail::check_alignment<min_aligned_elements_B>(make_shape(N, K, L), args.dB);
+
+    if (L > 1) {
+      constexpr int min_batch_aligned_elements_A = batch_alignment_bits / sizeof_bits<ElementA>::value;
+      constexpr int min_batch_aligned_elements_B = batch_alignment_bits / sizeof_bits<ElementB>::value;
+      implementable &= get<2>(args.dA) % min_batch_aligned_elements_A == 0;
+      implementable &= get<2>(args.dB) % min_batch_aligned_elements_B == 0;
+    }
+
+    return implementable;
+  }
+
+  template <class ScaleAFragment>
+  CUTLASS_DEVICE static void
+  load_block_scales(ScaleAFragment& fragment_scaleA,
+                    ElementAccumulator (&scale_b_cache)[N_ITERS],
+                    Params const& mainloop,
+                    int m_coord,
+                    int n_coord,
+                    int k_scale_idx,
+                    int batch_idx) {
+    const int M_extent = get<0>(mainloop.mAscale.shape());
+    const int N_extent = get<0>(mainloop.mBscale.shape());
+    const int lane_id = get_sub_group_local_id();
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int load_idx = 0; load_idx < ScaleAChunks; ++load_idx) {
+      const int m = m_coord + load_idx * SubgroupSize + lane_id;
+      fragment_scaleA(0, load_idx, 0) = m < M_extent
+          ? static_cast<ElementScaleA>(mainloop.mAscale(m, k_scale_idx, batch_idx))
+          : ElementScaleA(0);
+    }
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int ni = 0; ni < N_ITERS; ++ni) {
+      const int n = n_coord + ni * ATOM_N + lane_id;
+      scale_b_cache[ni] = n < N_extent
+          ? static_cast<float>(mainloop.mBscale(n, k_scale_idx, batch_idx))
+          : 0.0f;
+    }
+  }
+
+  template <class FrgTensorD, class RawAccum, class ScaleAFragment, class Subgroup>
+  CUTLASS_DEVICE static void
+  drain_block_cached(FrgTensorD& accum,
+                     RawAccum& raw_accum,
+                     ScaleAFragment& fragment_scaleA,
+                     ElementAccumulator const (&scale_b_cache)[N_ITERS],
+                     Subgroup sg_handle) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int mi = 0; mi < M_ITERS; ++mi) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int v = 0; v < ATOM_M; ++v) {
+        const int m_local = mi * ATOM_M + v;
+        const int load_idx = m_local / SubgroupSize;
+        const int lane_idx = m_local % SubgroupSize;
+        const float scale_a = static_cast<float>(group_broadcast(
+          sg_handle, fragment_scaleA(0, load_idx, 0), lane_idx));
+        CUTLASS_PRAGMA_UNROLL
+        for (int ni = 0; ni < N_ITERS; ++ni) {
+          accum(v, mi, ni) += static_cast<float>(raw_accum(v, mi, ni)) * scale_a * scale_b_cache[ni];
+          raw_accum(v, mi, ni) = int32_t(0);
+        }
+      }
+    }
+  }
+
+  template <class FrgTensorD, class RawAccum, class ScaleAFragment, class Subgroup>
+  CUTLASS_DEVICE static void
+  drain_block(FrgTensorD& accum,
+              RawAccum& raw_accum,
+              ScaleAFragment& fragment_scaleA,
+              Subgroup sg_handle,
+              Params const& mainloop,
+              int m_coord,
+              int n_coord,
+              int k_scale_idx,
+              int batch_idx) {
+    const int M_extent = get<0>(mainloop.mAscale.shape());
+    const int N_extent = get<0>(mainloop.mBscale.shape());
+    const int lane_id = get_sub_group_local_id();
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int load_idx = 0; load_idx < ScaleAChunks; ++load_idx) {
+      const int m = m_coord + load_idx * SubgroupSize + lane_id;
+      fragment_scaleA(0, load_idx, 0) = m < M_extent
+          ? static_cast<ElementScaleA>(mainloop.mAscale(m, k_scale_idx, batch_idx))
+          : ElementScaleA(0);
+    }
+
+    ElementAccumulator scale_b_cache[N_ITERS];
+    CUTLASS_PRAGMA_UNROLL
+    for (int ni = 0; ni < N_ITERS; ++ni) {
+      const int n = n_coord + ni * ATOM_N + lane_id;
+      scale_b_cache[ni] = n < N_extent
+          ? static_cast<float>(mainloop.mBscale(n, k_scale_idx, batch_idx))
+          : 0.0f;
+    }
+
+    drain_block_cached(accum, raw_accum, fragment_scaleA, scale_b_cache, sg_handle);
+  }
+
+  template <class FrgTensorD,
+            class TensorA,
+            class TensorB,
+            class FrgTensorC,
+            class KTileIterator,
+            class BlkCoord>
+  CUTLASS_DEVICE void
+  operator()(FrgTensorD& accum,
+             TensorA gA,
+             TensorB gB,
+             FrgTensorC const& src_accum,
+             KTileIterator k_tile_iter,
+             int k_tile_count,
+             BlkCoord const& blk_coord,
+             int const& K_start,
+             int thread_idx,
+             Params const& mainloop) {
+    static_assert(is_rmem<FrgTensorD>::value, "D tensor must be rmem resident.");
+    static_assert(is_rmem<FrgTensorC>::value, "C tensor must be rmem resident.");
+    (void)src_accum;
+
+    const int batch_idx = get<3>(blk_coord);
+    auto copy_a = get_block_2d_copy_A<GmemTiledCopyA>(TiledMma{}, mainloop.mA_mkl(_, _, batch_idx));
+    auto copy_b = get_block_2d_copy_B<GmemTiledCopyB>(TiledMma{}, mainloop.mB_nkl(_, _, batch_idx));
+    auto thr_copy_a = copy_a.get_slice(thread_idx);
+    auto thr_copy_b = copy_b.get_slice(thread_idx);
+
+    TiledMma tiled_mma;
+    auto thr_mma = tiled_mma.get_slice(thread_idx);
+    auto tCrA = thr_mma.partition_sg_fragment_A(gA(_, _, 0));
+    auto tCrB = thr_mma.partition_sg_fragment_B(gB(_, _, 0));
+    auto tArA = thr_copy_a.partition_sg_fragment_D(gA(_, _, 0));
+    auto tBrB = thr_copy_b.partition_sg_fragment_D(gB(_, _, 0));
+    Tensor tAgA = thr_copy_a.partition_S(gA);
+    Tensor tBgB = thr_copy_b.partition_S(gB);
+
+    auto prefetch_a = make_block_2d_prefetch(copy_a);
+    auto prefetch_b = make_block_2d_prefetch(copy_b);
+    auto thr_prefetch_A = prefetch_a.get_slice(thread_idx);
+    auto thr_prefetch_B = prefetch_b.get_slice(thread_idx);
+    Tensor pAgA = thr_prefetch_A.partition_S(gA);
+    Tensor pBgB = thr_prefetch_B.partition_S(gB);
+
+    auto raw_accum = make_fragment_like<int32_t>(accum);
+    clear(accum);
+    clear(raw_accum);
+    auto sg_handle = sycl::ext::oneapi::this_work_item::get_sub_group();
+    auto fragment_scaleA = make_tensor<ElementScaleA>(
+      Layout<Shape<_1, Int<ScaleAChunks>, _1>>{});
+    ElementAccumulator scale_b_cache[N_ITERS];
+
+    auto [m_idx, n_idx, k_idx, l_idx] = blk_coord;
+    const int m_coord = m_idx * BLK_M + (get_sub_group_id() / SG_NUMS_N) * SG_M;
+    const int n_coord = n_idx * BLK_N + (get_sub_group_id() % SG_NUMS_N) * SG_N;
+    int loaded_scale_idx = -1;
+
+    const int k_start_idx = crd2idx((*k_tile_iter), make_shape(K_start));
+    int prefetch_k = k_start_idx;
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < DispatchPolicy::Stages; ++i, ++prefetch_k) {
+      prefetch(prefetch_a, pAgA(_, _, _, prefetch_k));
+      prefetch(prefetch_b, pBgB(_, _, _, prefetch_k));
+    }
+
+    const int k_tile_end = k_start_idx + k_tile_count;
+    for (int k_tile = k_start_idx; k_tile < k_tile_end; ++k_tile, ++prefetch_k) {
+      if constexpr (GroupK == BLK_K) {
+        const int k_scale_idx = (k_tile * BLK_K) / GroupK;
+        if (k_scale_idx != loaded_scale_idx) {
+          load_block_scales(fragment_scaleA, scale_b_cache,
+                            mainloop, m_coord, n_coord, k_scale_idx, batch_idx);
+          loaded_scale_idx = k_scale_idx;
+        }
+      }
+        if (prefetch_k < k_tile_end) {
+          prefetch(prefetch_a, pAgA(_, _, _, prefetch_k));
+          prefetch(prefetch_b, pBgB(_, _, _, prefetch_k));
+        }
+
+
+      copy(copy_a, tAgA(_, _, _, k_tile), tArA);
+      copy(copy_b, tBgB(_, _, _, k_tile), tBrB);
+
+      reorder(tArA, tCrA);
+      reorder(tBrB, tCrB);
+      cute::gemm(tiled_mma, tCrA, tCrB, raw_accum);
+
+      const int k_end = (k_tile + 1) * BLK_K;
+      if (k_end % GroupK == 0) {
+        if constexpr (GroupK == BLK_K) {
+          drain_block_cached(accum, raw_accum, fragment_scaleA, scale_b_cache, sg_handle);
+        } else {
+          drain_block(accum, raw_accum, fragment_scaleA, sg_handle,
+                      mainloop, m_coord, n_coord,
+                      (k_end - 1) / GroupK, batch_idx);
+        }
+      }
+    }
+  }
+};
+
+} // namespace cutlass::gemm::collective

--- a/include/cutlass/gemm/dispatch_policy.hpp
+++ b/include/cutlass/gemm/dispatch_policy.hpp
@@ -1261,6 +1261,21 @@ struct MainloopIntelXeXMX16 {
   using ClusterShape = Shape<_1,_1,_1>;
 };
 
+template<int Stages_, int BlockK_, class KernelSchedule = KernelXe>
+struct MainloopIntelXeXMX16IntBlockScaled : MainloopIntelXeXMX16<Stages_, KernelSchedule> {
+  static_assert(BlockK_ == 128 || BlockK_ == 256, "Integer block scaling supports K blocks of 128 or 256.");
+  static_assert(BlockK_ % 32 == 0, "Integer block scaling K block must be divisible by the INT8 DPAS K tile.");
+  static constexpr int GroupK = BlockK_;
+};
+
+template<int Stages_, int BlockK_, class KernelSchedule = KernelXe>
+using MainloopIntelXeXMX16Int4BlockScaled =
+    MainloopIntelXeXMX16IntBlockScaled<Stages_, BlockK_, KernelSchedule>;
+
+template<int Stages_, int BlockK_, class KernelSchedule = KernelXe>
+using MainloopIntelXeXMX16Int8BlockScaled =
+    MainloopIntelXeXMX16IntBlockScaled<Stages_, BlockK_, KernelSchedule>;
+
 template<int Stages_, class KernelScheduler = KernelXePtrArrayCooperative>
 struct MainloopIntelXeXMX16Group : MainloopIntelXeXMX16<Stages_, KernelScheduler> {
 };


### PR DESCRIPTION
# Add BMG INT8/INT4 GEMM Templates, Fused Dequantization, and Block-Scaled Integer GEMM

## Description

This PR extends the BMG GEMM example with datatype-specialized template instantiations for signed INT8 and signed INT4 inputs. Both integer paths use INT32 accumulation and INT32 output, and are backed by dedicated CMake test targets with correctness verification enabled.

The implementation targets Intel Battlemage/BMG (`intel_gpu_bmg_g21`). The existing BF16 path remains the reference configuration and is benchmarked on the same workload for comparison. An isolated packed-B INT4 target is included as a secondary layout experiment.

The PR also adds standalone fused INT8 and INT4 dequantization examples. They use INT8 or signed INT4 A/B inputs, INT32 accumulation, FP32 compute, and FP32 or BF16 C/D output. A uses either a per-tensor or per-row scale, B uses a per-output-channel scale, and the epilogue computes:

`D[m,n] = alpha * scale_a[m] * scale_b[n] * int32_acc[m,n] + beta * C[m,n]`

For the per-tensor variant, `scale_a[m]` is replaced by the scalar `scale_a`.

The INT4 dequantization path uses the packed subbyte A/B storage required by the BMG INT4 mainloop. Its device batch strides are expressed in packed bytes (`M*K/2` for A and `N*K/2` for B), while the logical strides used by the reference computation remain element-based.

An optional packed-B variant uses `LayoutB = ColumnMajor`, making B K-contiguous in physical storage. It is reported separately because it assumes that B is already supplied in this packed layout and does not include a runtime layout conversion.

The PR also adds a block-scaled signed-integer GEMM path for both INT4xINT4 and INT8xINT8. A and B use one FP32 scale for each K block: A scales are indexed by `(M, K/GroupK, L)`, B scales by `(N, K/GroupK, L)`, and `GroupK` is either 128 or 256. The new Xe mainloop selects the raw INT4 or INT8 DPAS atom from the operand types, uses an INT32 raw accumulator, drains each completed K block once at the `GroupK` boundary, multiplies that block by the corresponding A/B scales, and accumulates the result into an FP32 fragment before the existing epilogue stores FP32 or BF16 output. The runner uses datatype-specific tiles: INT4 uses `128x256x128` with a `4x8` subgroup layout, while INT8 uses `256x128x64` with an `8x4` subgroup layout. GroupK=256 drains after two INT4 workgroup K tiles or four INT8 workgroup K tiles, so dequantization is performed once per scale block rather than once per DPAS tile. K must be divisible by the selected block size.

## Type

- [ ] Bug
- [x] Feature
- [x] Performance
- [ ] Refactor

## Optimization

- Add datatype-specialized BMG GEMM template instantiations for INT8 and signed INT4.
- Use `XE_DPAS_TT<8, ElementAccumulator, ElementInputA, ElementInputB>` so the same GEMM template is instantiated for BF16, INT8, and INT4 operands.
- Use INT32 for the integer accumulator, epilogue compute type, and output type.
- Use a `256x256x64` workgroup tile for the integer paths and `MainloopXeL1Staged<2>` with automatic Xe 2D global-memory copy selection.
- Use the tuned `4x8` subgroup layout for the INT4 path and retain the existing `8x4` layout for BF16 and INT8.
- For batched INT4 execution, pass the packed physical A/B batch strides at the BMG example boundary while keeping logical element strides for the reference GEMM.
- Add dedicated `00_bmg_gemm_int8` and `00_bmg_gemm_int4` test targets. Their default test configuration uses `512x512x512`, batch count 2, 20 iterations, and correctness verification.
- Add `00_bmg_gemm_int4_packed_b` as a secondary experiment. It uses `LayoutB = ColumnMajor` so the supplied B buffer is K-contiguous in physical memory; the existing RowMajor INT4 path remains unchanged.
- Add standalone fused INT8 and INT4 dequantization paths with FP32 and BF16 output variants.
- Support per-tensor and per-row A scales together with per-channel B scales while retaining INT32 accumulation and runtime alpha/beta handling.
- Use the Intel Xe `XeColBroadcast` and `XeRowBroadcast` visitors for the per-row A and per-channel B scale vectors.
- Initialize packed INT4 operands with the subbyte-aware `initialize_block` helper so the dequantization example uses the same physical representation as the INT4 GEMM path.
- Add four ColumnMajor packed-B variants of the INT4xINT4 fused dequantization path for layout/performance comparison.
- Add a BMG-specific `MainloopIntelXeXMX16IntBlockScaled` mainloop for K-blocked signed-integer dequantization and accumulation, with the old INT4 policy name retained as an alias.
- Add a raw-operation-parameterized block-scaled Xe MMA atom and FP32 fragment traits for signed INT4xINT4 and INT8xINT8, while retaining the named INT4 atom alias.
- Support block sizes 128 and 256 with ColumnMajor packed B and FP32 or BF16 output through four INT4 and four INT8 targets.
- Keep raw INT4 or INT8 DPAS accumulation in INT32 and perform the per-block scale product in the mainloop so scales are applied before the next K block is accumulated.
- Use `Shape<_128, _256, _128>` with a `4x8` subgroup layout for INT4 and `Shape<_256, _128, _64>` with an `8x4` subgroup layout for INT8. GroupK=256 drains after two INT4 workgroup K tiles or four INT8 workgroup K tiles instead of increasing the K fragment to 256.
- Drain the raw accumulator only when `k_end % GroupK == 0`, reducing dequantization from once per 64-K tile to once per scale block.
- Load A scales into a compact per-subgroup fragment and use subgroup broadcast during drain so all lanes do not reload the same row scales.
- Cache each lane's B scale once per block drain, outside the nested M-fragment loops, to avoid repeating the same scale load and address calculation for every accumulator row.

## Profiling

Tool: `GPU_Clock` timing in the BMG GEMM examples.

The original INT8/INT4 comparison uses 100 steady-state GEMM iterations. The fused dequantization and block-scaled comparisons use 500 iterations to reduce timing noise.

Workload: `M=5120, N=4096, K=4096, L=1`.

Hardware/toolchain: Intel Arc Pro B60/Battlemage, oneAPI 2025.3, `spir64_gen`, GRF256.

The AOT image used for the measurements was configured with the quoted backend option below. Runtime GRF-related environment variables do not change an already generated `spir64_gen` image.

```text
-Xsycl-target-backend "-options -cl-intel-256-GRF-per-thread"
```

The reported TOPS/TFLOP/s values use the same `2*M*N*K` GEMM operation count. BF16 is printed as TFLOP/s by the original example, while the integer targets are printed as TOPS; the numerical throughput values are directly comparable.

The main comparison measures the new INT8 and INT4 template instantiations against the existing BF16 configuration. The packed-B result is reported separately because it assumes a pre-arranged physical B layout and does not include a packing conversion. The fused dequantization results are reported separately because they include additional epilogue scale loads and are not directly comparable to the pure INT8 GEMM target.

## Results

| Case | Target | Throughput | Latency | Relative to BF16 |
|------|--------|------------|---------|------------------|
| BF16 reference | `00_bmg_gemm` | 90.190 TFLOP/s | 1.9049 ms | 1.00x |
| INT8 | `00_bmg_gemm_int8` | 181.370 TOPS | 0.9472 ms | 2.011x throughput, 50.3% lower latency |
| INT4, RowMajor B | `00_bmg_gemm_int4` | 275.656 TOPS | 0.6232 ms | 3.056x throughput, 67.3% lower latency |

Secondary packed-B experiment:

| Case | Target | Throughput | Latency | Relative to BF16 |
|------|--------|------------|---------|------------------|
| INT4, K-contiguous packed B | `00_bmg_gemm_int4_packed_b` | 307.763 TOPS | 0.5582 ms | 3.412x throughput, 70.7% lower latency |

The packed-B result assumes that B is already supplied in the K-contiguous physical layout. Runtime RowMajor-to-packed conversion and its one-time cost are not included in this benchmark, so it is not the primary INT4 comparison.

Fused INT8 dequantization comparison:

| A scale | C/D type | Target | Throughput | Latency | Relative to matching per-tensor path |
|---------|----------|--------|------------|---------|----------------------------------------|
| Per-tensor | FP32 | `00_bmg_gemm_int8_dequant_fp32` | 175.943 TOPS | 0.9764 ms | 1.00x |
| Per-row | FP32 | `00_bmg_gemm_int8_dequant_per_row_a_fp32` | 163.273 TOPS | 1.0522 ms | 7.8% higher latency |
| Per-tensor | BF16 | `00_bmg_gemm_int8_dequant_bf16` | 170.687 TOPS | 1.0065 ms | 1.00x |
| Per-row | BF16 | `00_bmg_gemm_int8_dequant_per_row_a_bf16` | 161.680 TOPS | 1.0626 ms | 5.6% higher latency |

The per-row scale path is functionally correct but slower because the Xe epilogue performs per-row scale loads and coordinate/bounds handling. The reported TOPS values use the GEMM operation count `2*M*N*K`; the extra dequantization operations are not added to the numerator.

Fused INT4 dequantization comparison:

| A scale | C/D type | Target | Throughput | Latency | Relative to matching per-tensor path |
|---------|----------|--------|------------|---------|----------------------------------------|
| Per-tensor | FP32 | `00_bmg_gemm_int4_dequant_fp32` | 261.512 TOPS | 0.6569 ms | 1.00x |
| Per-row | FP32 | `00_bmg_gemm_int4_dequant_per_row_a_fp32` | 261.727 TOPS | 0.6564 ms | 0.1% lower latency |
| Per-tensor | BF16 | `00_bmg_gemm_int4_dequant_bf16` | 267.962 TOPS | 0.6411 ms | 1.00x |
| Per-row | BF16 | `00_bmg_gemm_int4_dequant_per_row_a_bf16` | 246.556 TOPS | 0.6968 ms | 8.7% higher latency |

The INT4 dequantization targets use the same `2*M*N*K` numerator as the pure integer GEMM results. The per-row FP32 measurement is within timing noise of the per-tensor path, while the BF16 per-row path shows the expected additional scale/broadcast overhead.

Fused INT4 dequantization with ColumnMajor packed B:

| A scale | C/D type | Target | Throughput | Latency | Relative to RowMajor B |
|---------|----------|--------|------------|---------|------------------------|
| Per-tensor | FP32 | `00_bmg_gemm_int4_dequant_packed_b_fp32` | 286.764 TOPS | 0.5991 ms | 9.7% higher throughput, 8.8% lower latency |
| Per-row | FP32 | `00_bmg_gemm_int4_dequant_packed_b_per_row_a_fp32` | 271.210 TOPS | 0.6335 ms | 3.6% higher throughput, 3.5% lower latency |
| Per-tensor | BF16 | `00_bmg_gemm_int4_dequant_packed_b_bf16` | 298.098 TOPS | 0.5763 ms | 11.2% higher throughput, 10.1% lower latency |
| Per-row | BF16 | `00_bmg_gemm_int4_dequant_packed_b_per_row_a_bf16` | 260.718 TOPS | 0.6589 ms | 5.7% higher throughput, 5.4% lower latency |

The ColumnMajor packed-B runs use the same workload and runtime configuration as the RowMajor B runs. The improvement comes from supplying B in the K-contiguous physical layout; no packing conversion is included in the measured time.

Block-scaled integer GEMM comparison:

| Datatype | K block | B layout | C/D type | Target | Throughput | Latency |
|----------|---------|----------|----------|--------|------------|---------|
| INT4 | 128 | ColumnMajor packed B | FP32 | `00_bmg_gemm_int4_block_scaled_128_packed_b_fp32` | 171.732 TOPS | 1.0004 ms |
| INT4 | 128 | ColumnMajor packed B | BF16 | `00_bmg_gemm_int4_block_scaled_128_packed_b_bf16` | 177.020 TOPS | 0.9705 ms |
| INT4 | 256 | ColumnMajor packed B | FP32 | `00_bmg_gemm_int4_block_scaled_256_packed_b_fp32` | 217.096 TOPS | 0.7913 ms |
| INT4 | 256 | ColumnMajor packed B | BF16 | `00_bmg_gemm_int4_block_scaled_256_packed_b_bf16` | 221.568 TOPS | 0.7754 ms |
| INT8 | 128 | ColumnMajor packed B | FP32 | `00_bmg_gemm_int8_block_scaled_128_packed_b_fp32` | 84.026 TOPS | 2.0446 ms |
| INT8 | 128 | ColumnMajor packed B | BF16 | `00_bmg_gemm_int8_block_scaled_128_packed_b_bf16` | 82.819 TOPS | 2.0744 ms |
| INT8 | 256 | ColumnMajor packed B | FP32 | `00_bmg_gemm_int8_block_scaled_256_packed_b_fp32` | 92.480 TOPS | 1.8577 ms |
| INT8 | 256 | ColumnMajor packed B | BF16 | `00_bmg_gemm_int8_block_scaled_256_packed_b_bf16` | 100.609 TOPS | 1.7076 ms |

The block-scaled measurements use the same `2*M*N*K` numerator as the other integer paths. The mainloop keeps both an FP32 scaled accumulator and an INT32 raw DPAS accumulator. INT4 uses `Shape<_128, _256, _128>` with `4x8`; INT8 uses `Shape<_256, _128, _64>` with `8x4`. GroupK=128 drains after one INT4 tile or two INT8 tiles; GroupK=256 drains after two INT4 tiles or four INT8 tiles, so the scale product is applied once per K block. Because the Xe 2D loads target registers directly and the kernel has no SLM staging, the block-scaled mainloop does not use a workgroup barrier. For GroupK=128, A and B scales are preloaded once per K tile and reused by the drain; GroupK=256 retains drain-time scale loading to avoid extending scale-cache lifetimes across multiple tiles. Compact subgroup A-scale loading and cached per-lane B scales keep the drain work bounded. A/B cache prefetch remains two K tiles ahead and before GEMM; a one-tile distance was neutral, while a three-tile distance and post-drain prefetch were slower. The retained builds emitted no spill warning with this configuration, and the INT8 measurements above reflect the dedicated INT8 tile and GRF256 AOT image.

## Changes

- `examples/00_bmg_gemm/00_bmg_gemm.cpp`
  - Adds INT8 and signed INT4 datatype aliases.
  - Instantiates the common `TiledMma` template with BF16, INT8, and INT4 operand types.
  - Selects INT32 accumulator, epilogue compute, and output types for integer targets.
  - Adds the integer tile and subgroup configuration.
  - Reports integer performance in TOPS while retaining BF16 TFLOP/s reporting.
  - Adds the optional packed-B layout specialization.
  - Uses physical packed-byte batch strides for INT4 mainloop inputs while the verification reference retains logical INT4 strides.
- `examples/00_bmg_gemm/00_bmg_gemm_int8_dequant.cpp`
  - Adds fused INT8 dequantization with INT32 accumulation and FP32 epilogue computation.
  - Supports per-tensor A scale, per-row A scale, and per-channel B scale.
  - Supports FP32 and BF16 C/D output with alpha and beta.
- `examples/00_bmg_gemm/00_bmg_gemm_int4_dequant.cpp`
  - Adds the analogous fused INT4xINT4 dequantization path with INT32 accumulation.
  - Uses packed INT4 A/B storage and physical packed-byte batch strides.
  - Supports per-tensor or per-row A scales, per-channel B scales, and FP32/BF16 C/D output.
- `examples/00_bmg_gemm/00_bmg_gemm_int4_block_scaled.cpp`
  - Adds the block-scaled signed-integer runner and reference validation for INT4xINT4 and INT8xINT8.
  - Generates A `(M, K/GroupK, L)` and B `(N, K/GroupK, L)` FP32 scales.
  - Supports `GroupK=128` and `GroupK=256` with ColumnMajor packed B and FP32/BF16 output.
  - Uses `Shape<_128, _256, _128>` with `4x8` for INT4 and `Shape<_256, _128, _64>` with `8x4` for INT8.
  - Drains only at scale-block boundaries: two INT4 K tiles or four INT8 K tiles for `GroupK=256`.
- `include/cutlass/gemm/collective/xe_mma_int4_blockscaled.hpp`
  - Adds the BMG block-scaled mainloop specialization.
  - Performs raw INT32 DPAS per K tile and drains each completed scale block into the FP32 accumulator fragment.
  - Uses compact subgroup A-scale loading and cached per-lane B scales in the drain path.
  - Uses direct register 2D loads without a workgroup barrier and preloads the single-tile GroupK=128 scales.
  - Allows a non-aligned M extent for A while retaining the N/K and dynamic stride alignment checks required by the Xe 2D path.
- `include/cute/arch/mma_xe.hpp` and `include/cute/atom/mma_traits_xe.hpp`
  - Add the raw-operation-parameterized block-scaled MMA operation and its FP32 fragment traits for signed INT4 and INT8 while retaining the raw DPAS implementations.
- `include/cutlass/gemm/dispatch_policy.hpp` and `include/cutlass/gemm/collective/collective_mma.hpp`
  - Register and dispatch the new Xe block-scaled mainloop policy.
- `examples/00_bmg_gemm/CMakeLists.txt`
  - Adds the `00_bmg_gemm_int8` correctness/performance test target.
  - Adds the `00_bmg_gemm_int4` correctness/performance test target.
  - Adds the secondary `00_bmg_gemm_int4_packed_b` target.
  - Adds FP32/BF16 fused dequantization targets for per-tensor A scale.
  - Adds FP32/BF16 fused dequantization targets for per-row A scale.
  - Adds the four corresponding INT4xINT4 fused dequantization targets.
  - Adds four ColumnMajor packed-B INT4xINT4 fused dequantization targets.
  - Adds four ColumnMajor packed-B block-scaled INT4xINT4 targets covering two K block sizes and two output types.
  - Adds four corresponding ColumnMajor packed-B block-scaled INT8xINT8 targets.
  - Supplies the standard integer test shape and verification options.

## Testing

Build command:

```bash
ninja -C /home/yuluo/stla/build \
  00_bmg_gemm \
  00_bmg_gemm_int8 \
  00_bmg_gemm_int4 \
  00_bmg_gemm_int4_packed_b \
  00_bmg_gemm_int8_dequant_fp32 \
  00_bmg_gemm_int8_dequant_bf16 \
  00_bmg_gemm_int8_dequant_per_row_a_fp32 \
  00_bmg_gemm_int8_dequant_per_row_a_bf16 \
  00_bmg_gemm_int4_dequant_packed_b_fp32 \
  00_bmg_gemm_int4_dequant_packed_b_bf16 \
  00_bmg_gemm_int4_dequant_packed_b_per_row_a_fp32 \
  00_bmg_gemm_int4_dequant_packed_b_per_row_a_bf16 \
  00_bmg_gemm_int4_dequant_fp32 \
  00_bmg_gemm_int4_dequant_bf16 \
  00_bmg_gemm_int4_dequant_per_row_a_fp32 \
  00_bmg_gemm_int4_dequant_per_row_a_bf16 \
  00_bmg_gemm_int4_block_scaled_128_packed_b_fp32 \
  00_bmg_gemm_int4_block_scaled_128_packed_b_bf16 \
  00_bmg_gemm_int4_block_scaled_256_packed_b_fp32 \
  00_bmg_gemm_int4_block_scaled_256_packed_b_bf16 \
  00_bmg_gemm_int8_block_scaled_128_packed_b_fp32 \
  00_bmg_gemm_int8_block_scaled_128_packed_b_bf16 \
  00_bmg_gemm_int8_block_scaled_256_packed_b_fp32 \
  00_bmg_gemm_int8_block_scaled_256_packed_b_bf16
```

Result: the BF16 reference, all three integer targets, all twelve fused dequantization targets, and all eight block-scaled targets built successfully for BMG.

Correctness checks:

```bash
# The following runtime environment was used for each command.
export LD_LIBRARY_PATH=/home/yuluo/intel/oneapi/2025.3/lib:/home/yuluo/intel/oneapi/compiler/2025.3/lib:$LD_LIBRARY_PATH
export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
export SYCL_PROGRAM_COMPILE_OPTIONS=-ze-opt-large-register-file
export IGC_VectorAliasBBThreshold=10000
export IGC_ExtraOCLOptions=-cl-intel-256-GRF-per-thread
unset IGC_VISAOptions

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_packed_b \
  --m=512 --n=512 --k=512 --l=2 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4 \
  --m=512 --n=512 --k=512 --l=2 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8 \
  --m=512 --n=512 --k=512 --l=2 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_dequant_fp32 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_dequant_per_row_a_fp32 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_dequant_per_row_a_bf16 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_fp32 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_bf16 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_per_row_a_fp32 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_per_row_a_bf16 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_packed_b_fp32 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_packed_b_bf16 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_packed_b_per_row_a_fp32 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_packed_b_per_row_a_bf16 \
  --m=512 --n=512 --k=512 --l=2 --alpha=1.25 --beta=0.5 --scale-a=0.125 --iterations=0 --verify=1
```

Result: the direct INT8/INT4 correctness checks and all twelve fused dequantization checks reported `Disposition: Passed`, including the batched cases. An additional valid `512x512x576x2` RowMajor B INT4 per-row-A FP32 case passed to exercise a non-full K extent. The existing INT8/INT4 and fused-dequant paths remain unchanged; the block-scaled behavior is localized to the new BMG dispatch policy, MMA traits, collective mainloop, and example runner.

The four existing ColumnMajor packed-B INT4 block-scaled targets also reported `Disposition: Passed` on `512x512x512x2` with `alpha=1.25`, `beta=0.5`, and `--verify=1`. The new INT8 `GroupK=128` and `GroupK=256` targets passed batched `128x256x128x2` and `128x256x256x2` checks for both FP32 and BF16 output. These workloads contain one scale block for `GroupK=128` and one scale block for `GroupK=256` in the focused checks.

The CMake targets also register the integer example test configuration with `512x512x512`, batch count 2, 20 iterations, and `--verify=1`. With the BMG runtime environment above, the registered `ctest_examples_00_bmg_gemm_int8`, `ctest_examples_00_bmg_gemm_int4`, and `ctest_examples_00_bmg_gemm_int4_packed_b` tests all passed.

The relaxed A-side alignment check was validated independently of the retained B-side constraint. Both the INT8 and INT4 block-scaled FP32 targets passed with `M=513, N=512, K=512, L=1`, while the INT8 target correctly rejected `M=512, N=513, K=512, L=1` as an invalid problem. Thus M may be non-aligned, while the N/K alignment and dynamic stride checks required by the Xe 2D path remain active.

```bash
/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_block_scaled_128_packed_b_fp32 \
  --m=513 --n=512 --k=512 --l=1 --iterations=0 --verify=1

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_block_scaled_128_packed_b_fp32 \
  --m=513 --n=512 --k=512 --l=1 --iterations=0 --verify=1

# Expected result: Invalid Problem Size: 512x513x512x1
/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_block_scaled_128_packed_b_fp32 \
  --m=512 --n=513 --k=512 --l=1 --iterations=0 --verify=1
```

Performance command:

```bash
/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=100 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=100 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=100 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_packed_b \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=100 --verify=0

# Fused INT8 dequantization targets; each command uses 500 iterations.
/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_dequant_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_dequant_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_dequant_per_row_a_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_dequant_per_row_a_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

# Fused INT4 dequantization targets; each command uses 500 iterations.
/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_per_row_a_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_per_row_a_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

# Fused INT4 dequantization with ColumnMajor packed B; each command uses 500 iterations.
/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_packed_b_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_packed_b_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_packed_b_per_row_a_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_dequant_packed_b_per_row_a_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

# Block-scaled INT4 GEMM targets with ColumnMajor packed B; each command uses 500 iterations.
/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_block_scaled_128_packed_b_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_block_scaled_128_packed_b_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_block_scaled_256_packed_b_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int4_block_scaled_256_packed_b_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

# Block-scaled INT8 GEMM targets with ColumnMajor packed B; each command uses 500 iterations.
/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_block_scaled_128_packed_b_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_block_scaled_128_packed_b_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_block_scaled_256_packed_b_fp32 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0

/home/yuluo/stla/build/examples/00_bmg_gemm/00_bmg_gemm_int8_block_scaled_256_packed_b_bf16 \
  --m=5120 --n=4096 --k=4096 --l=1 --iterations=500 --verify=0
```

Results are reported in the comparison tables above. The packed-B run measured `307.763 TOPS` at `0.5582 ms` average latency. The four fused dequantization runs measured the values in the fused dequantization table above.
The four fused INT4 dequantization runs measured the values in the INT4 fused dequantization table above.
The four ColumnMajor packed-B fused INT4 dequantization runs measured the values in the corresponding table above.
The four ColumnMajor packed-B block-scaled INT4 runs measured the values in the block-scaled table above.
The four ColumnMajor packed-B block-scaled INT8 runs measured the values in the block-scaled table above.

Additional validation:

- `git diff --check` passed.
- BF16, INT8, and INT4 were benchmarked with the same problem size and runtime environment.
- All four INT4 fused dequantization variants passed batched correctness; the per-row-A FP32 variant also passed the valid `512x512x576x2` K-tail case.
- All four ColumnMajor packed-B INT4 fused dequantization variants passed batched correctness.
- All four ColumnMajor packed-B block-scaled INT4 variants passed batched correctness with nonzero alpha and beta.
- Both INT4 and INT8 block-scaled FP32 targets passed `M=513, N=512, K=512, L=1`; the corresponding `N=513` INT8 case remained invalid as expected.
- A-side M shape alignment is no longer required; A K/stride alignment, B N/K/stride alignment, and batch-stride alignment checks remain enforced.
- The block-scaled path enforces `K % GroupK == 0` for `GroupK=128` or `GroupK=256`.
- Xe20/BMG runtime validation completed.
- Xe12/PVC validation was not performed.
- The full clean repository build and full unit-test suite were not run for this PR.

## References

Related: N/A

## Checklist

- [x] Copyright
- [x] Co-pilot Review
- [x] Deprecated APIs not used
- [x] Xe20/BMG validation
- [ ] Xe12/PVC validation
