### PR TITLE
Fix device-agnostic fp32 GEMM compile on oneAPI 2025.2+

### DIFF
--- a/include/cutlass/arch/cache_operation.h
+++ b/include/cutlass/arch/cache_operation.h
@@ -42,7 +42,7 @@ namespace arch {
 
 /// Controls PTX cache operations
 struct CacheOperation {
-  enum Kind {
+  enum Kind : unsigned char {
     /// Cache at all levels - accessed again
     Always,
     /// Cache at global level

--- a/include/cutlass/arch/memory.h
+++ b/include/cutlass/arch/memory.h
@@ -109,6 +109,8 @@ struct global_load<AccessType,
         : "l"(ptr), "r"((int)pred_guard), "r"(data[0].x), "r"(data[0].y),
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -145,6 +147,8 @@ struct global_load<AccessType,
         : "l"(ptr), "r"((int)pred_guard), "r"(data[0].x), "r"(data[0].y),
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -177,6 +181,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -205,6 +211,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -235,6 +243,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -261,6 +271,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -290,6 +302,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -315,6 +329,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -344,6 +360,8 @@ struct global_load<AccessType,
         "}\n"
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -369,6 +387,8 @@ struct global_load<AccessType,
         "}\n"
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) D = *(reinterpret_cast<AccessType const *>(ptr));
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -427,6 +447,8 @@ struct global_store<AccessType, 64> {
         "r"(data[2].x), "r"(data[2].y), "r"(data[2].z), "r"(data[2].w),
         "l"(((uint8_t *)ptr) + 48),
         "r"(data[3].x), "r"(data[3].y), "r"(data[3].z), "r"(data[3].w));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) *(reinterpret_cast<AccessType *>(ptr)) = D;
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -452,6 +474,8 @@ struct global_store<AccessType, 32> {
       : "l"(ptr), "r"(data[0].x), "r"(data[0].y), "r"(data[0].z),
         "r"(data[0].w), "r"((int)pred_guard), "l"(((uint8_t *)ptr) + 16),
         "r"(data[1].x), "r"(data[1].y), "r"(data[1].z), "r"(data[1].w));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) *(reinterpret_cast<AccessType *>(ptr)) = D;
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -473,6 +497,8 @@ struct global_store<AccessType, 16> {
       "}\n"
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w), "r"((int)pred_guard));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) *(reinterpret_cast<AccessType *>(ptr)) = D;
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -494,6 +520,8 @@ struct global_store<AccessType, 8> {
       "}\n"
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"((int)pred_guard));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) *(reinterpret_cast<AccessType *>(ptr)) = D;
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -515,6 +543,8 @@ struct global_store<AccessType, 4> {
       "}\n"
       :
       : "l"(ptr), "r"(data), "r"((int)pred_guard));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) *(reinterpret_cast<AccessType *>(ptr)) = D;
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
@@ -536,6 +566,8 @@ struct global_store<AccessType, 2> {
       "}\n"
       :
       : "l"(ptr), "h"(data), "r"((int)pred_guard));
+#elif defined(__SYCL_DEVICE_ONLY__)
+  if (pred_guard) *(reinterpret_cast<AccessType *>(ptr)) = D;
 #else
   CUTE_INVALID_CONTROL_PATH(
       "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");

--- a/include/cutlass/arch/mma.h
+++ b/include/cutlass/arch/mma.h
@@ -206,7 +206,7 @@ struct Mma<gemm::GemmShape<1, 1, 1>, 1, ElementA, LayoutA, ElementB, LayoutB, El
 
 /// Specifies internal data type for computation
 struct SPFormatType {
-  enum Kind {
+  enum Kind : unsigned char {
     Thread
   };
 };

--- a/include/cutlass/epilogue/thread/scale_type.h
+++ b/include/cutlass/epilogue/thread/scale_type.h
@@ -49,7 +49,7 @@ namespace thread {
 ///  1. Scalar means alpha/beta is a single value from host(constant param) or device memory.
 ///  2. Vector means alpha/beta is a vector always from device memory.
 struct ScaleType {
-  enum Kind {
+  enum Kind : unsigned char {
     Default,                           // D = scalar_alpha x Acc + scalar_beta x C
     NoBetaScaling,                     // D = scalar_alpha x Acc + C
     OnlyAlphaScaling,                  // D = scalar_alpha x Acc

--- a/include/cutlass/gemm/device/gemm_universal_adapter.h
+++ b/include/cutlass/gemm/device/gemm_universal_adapter.h
@@ -605,10 +605,13 @@ public:
           sycl_grid, sycl_block, launch_props, kernel_props
         };
 #if defined(CUTLASS_SYCL_PROFILING_ENABLED)
-        auto event = compat::experimental::launch<device_kernel<GemmKernel>, GemmKernel>(policy, q, params);
+        auto event = compat::experimental::launch<device_kernel<GemmKernel>>(
+            policy, q, params);
         EventManager::getInstance().addEvent(event);
 #else
-        compat::experimental::launch<device_kernel<GemmKernel>, GemmKernel, false>(policy, q, params);
+        compat::experimental::launch<device_kernel<GemmKernel>,
+                                     sycl::detail::auto_name, false>(policy,
+                                                                     q, params);
 #endif
 #endif // !defined(SYCL_EXT_ONEAPI_WORK_GROUP_SCRATCH_MEMORY)
 #else


### PR DESCRIPTION
## Context

We recently added support for sparse convolutions and continuous convolutions in [Open3D](https://github.com/isl-org/Open3D) for 3D point cloud data using sycl-tla. We ran into this issue. Currently, Open3D maintains this PR as a [patch](https://github.com/isl-org/Open3D/blob/main/3rdparty/sycl_tla/0001-fix-oneapi-2025.3-ieee-gemm.patch).

## Description

Device-agnostic fp32 `GemmUniversalAdapter::run()` fails to compile on oneAPI 2025.2+ (reproduced on **2026.0**):

```text
error: unscoped enum 'Kind' requires fixed underlying type
```

This patch:

1. Gives fixed underlying types to `Kind` enums used in kernel metadata (`scale_type.h`, `cache_operation.h`, `mma.h`).
2. Uses `sycl::detail::auto_name` on the work-group-scratch launch path ([#803](https://github.com/intel/sycl-tla/pull/803) only fixed the other branch).
3. Adds `__SYCL_DEVICE_ONLY__` fallbacks in `arch/memory.h` for global load/store (replacing CUDA-only / invalid paths on Intel GPU).

---

## Type

- [x] Bug

---

## Testing

- [ ] Tests pass (sycl-tla CI — not run by PR author)
- [x] A770
- [x] Panther Lake

### What was verified (author machine)

| Check | Without patch | With patch |
|-------|---------------|------------|
| `mre_compile_only.cpp` device compile | Fails (`Kind` error, exit 1) | OK (exit 0) |
| `mre_device_agnostic_fp32_gemm.cpp` device compile | Fails (same error, exit 1) | OK (exit 0) |
| `mre_device_agnostic_fp32_gemm.cpp` link + run | Not run (no build) | OK; prints `OK: device-agnostic fp32 GEMM completed` (exit 0) |

Environment: **oneAPI 2026.0** (`icpx` 2026.0.0.20260331), sycl-tla **`main` @ `2db1b7c`**, Intel GPU **`0xb080`**, runtime via **`ONEAPI_DEVICE_SELECTOR=level_zero:gpu`** only.

### Not verified

- oneAPI **2025.2 / 2025.3** (only 2026.0 retested end-to-end)
- **OpenCL** SYCL backend for the runtime MRE
- **Xe20** hardware or sycl-tla CI

### How to reproduce

From a sycl-tla repository root, save the two sources below as `mre_compile_only.cpp` and `mre_device_agnostic_fp32_gemm.cpp`, then:

```bash
source /opt/intel/oneapi/setvars.sh   # or oneapi-vars.sh for your install

ICXX_FLAGS="-std=c++17 -fsycl -DCUTLASS_ENABLE_SYCL=1 -DSYCL_INTEL_TARGET=1 \
  -I include -I tools/util/include"

# Before applying this PR's header changes:
icpx $ICXX_FLAGS -c mre_compile_only.cpp                    # expect Kind error
icpx $ICXX_FLAGS -c mre_device_agnostic_fp32_gemm.cpp      # expect Kind error

# After applying the PR:
icpx $ICXX_FLAGS -c mre_compile_only.cpp                    # expect success
icpx $ICXX_FLAGS mre_device_agnostic_fp32_gemm.cpp -o mre_gemm
ONEAPI_DEVICE_SELECTOR=level_zero:gpu ./mre_gemm                   # expect OK line above
```

<details>
<summary><code>mre_compile_only.cpp</code> (compile-only repro)</summary>

```cpp
// SPDX-License-Identifier: BSD-3-Clause
#include <cutlass/epilogue/collective/collective_builder.hpp>
#include <cutlass/gemm/collective/collective_builder.hpp>
#include <cutlass/gemm/device/gemm_universal_adapter.h>
#include <cutlass/layout/matrix.h>
#include <cute/tensor.hpp>
#include <sycl/sycl.hpp>

using Element = float;
using LayoutA = cutlass::layout::ColumnMajor;
using LayoutB = cutlass::layout::RowMajor;
using LayoutC = cutlass::layout::RowMajor;
using TileShape = cute::Shape<cute::_64, cute::_64, cute::_16>;

using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
    cutlass::arch::Agnostic, cutlass::arch::OpMultiplyAdd,
    Element, LayoutA, 4, Element, LayoutB, 4, Element, TileShape,
    cute::Shape<cute::_1, cute::_1, cute::_1>,
    cutlass::gemm::collective::StageCountAuto,
    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;

using EpilogueOp =
    cutlass::epilogue::fusion::LinearCombination<Element, Element, Element, Element>;
using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
    cutlass::arch::Agnostic, cutlass::arch::OpMultiplyAdd, TileShape,
    cute::Shape<cute::_1, cute::_1, cute::_1>,
    cutlass::epilogue::collective::EpilogueTileAuto, Element, Element,
    Element, LayoutC, 4, Element, LayoutC, 4,
    cutlass::epilogue::collective::EpilogueScheduleAuto, EpilogueOp>::CollectiveOp;

using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
    cute::Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue>;
using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;

int main() {
    sycl::queue q;
    Gemm gemm;
    typename Gemm::Arguments args{};
    gemm.initialize(args, nullptr, &q);
    return gemm.run(&q) == cutlass::Status::kSuccess ? 0 : 1;
}
```

</details>

<details>
<summary><code>mre_device_agnostic_fp32_gemm.cpp</code> (compile + GPU runtime smoke)</summary>

```cpp
// SPDX-License-Identifier: BSD-3-Clause
#include <cutlass/epilogue/collective/collective_builder.hpp>
#include <cutlass/gemm/collective/collective_builder.hpp>
#include <cutlass/gemm/device/gemm_universal.h>
#include <cutlass/gemm/device/gemm_universal_adapter.h>
#include <cutlass/kernel_hardware_info.h>
#include <cutlass/layout/matrix.h>
#include <cutlass/util/packed_stride.hpp>

#include <cute/tensor.hpp>
#include <cstdlib>
#include <iostream>
#include <sycl/sycl.hpp>
#include <vector>

namespace {

using Element = float;
using LayoutA = cutlass::layout::ColumnMajor;
using LayoutB = cutlass::layout::RowMajor;
using LayoutC = cutlass::layout::RowMajor;
using TileShape = cute::Shape<cute::_64, cute::_64, cute::_16>;

using CollectiveMainloop =
    typename cutlass::gemm::collective::CollectiveBuilder<
        cutlass::arch::Agnostic, cutlass::arch::OpMultiplyAdd, Element,
        LayoutA, 4, Element, LayoutB, 4, Element, TileShape,
        cute::Shape<cute::_1, cute::_1, cute::_1>,
        cutlass::gemm::collective::StageCountAuto,
        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;

using EpilogueOp = cutlass::epilogue::fusion::LinearCombination<
    Element, Element, Element, Element>;

using CollectiveEpilogue =
    typename cutlass::epilogue::collective::CollectiveBuilder<
        cutlass::arch::Agnostic, cutlass::arch::OpMultiplyAdd, TileShape,
        cute::Shape<cute::_1, cute::_1, cute::_1>,
        cutlass::epilogue::collective::EpilogueTileAuto, Element, Element,
        Element, LayoutC, 4, Element, LayoutC, 4,
        cutlass::epilogue::collective::EpilogueScheduleAuto,
        EpilogueOp>::CollectiveOp;

using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
    cute::Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue>;

using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;

}  // namespace

int main() {
    sycl::queue q(sycl::gpu_selector_v);
    const int m = 64, n = 64, k = 16;
    const float alpha = 1.f, beta = 0.f;

    std::vector<float> h_a(m * k, 1.f), h_b(k * n, 2.f), h_c(m * n, 0.f),
        h_d(m * n, 0.f);
    float *d_a = sycl::malloc_device<float>(h_a.size(), q);
    float *d_b = sycl::malloc_device<float>(h_b.size(), q);
    float *d_c = sycl::malloc_device<float>(h_c.size(), q);
    float *d_d = sycl::malloc_device<float>(h_d.size(), q);
    q.memcpy(d_a, h_a.data(), h_a.size() * sizeof(float)).wait();
    q.memcpy(d_b, h_b.data(), h_b.size() * sizeof(float)).wait();
    q.memcpy(d_c, h_c.data(), h_c.size() * sizeof(float)).wait();

    using StrideA = typename Gemm::GemmKernel::StrideA;
    using StrideB = typename Gemm::GemmKernel::StrideB;
    using StrideC = typename Gemm::GemmKernel::StrideC;
    using StrideD = typename Gemm::GemmKernel::StrideD;

    const int batch = 1;
    StrideA stride_a =
        cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(m, k, batch));
    StrideB stride_b =
        cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(n, k, batch));
    StrideC stride_c =
        cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(m, n, batch));
    StrideD stride_d = stride_c;

    cutlass::KernelHardwareInfo hw_info;
    hw_info.sm_count = 1;

    typename Gemm::GemmKernel::Arguments args{
        cutlass::gemm::GemmUniversalMode::kGemm, {m, n, k, 1},
        {d_a, stride_a, d_b, stride_b},
        {{alpha, beta}, d_c, stride_c, d_d, stride_d}, hw_info};

    Gemm gemm;
    void *workspace = nullptr;
    size_t ws = Gemm::get_workspace_size(args);
    if (ws) workspace = sycl::malloc_device(ws, q);

    if (gemm.can_implement(args) != cutlass::Status::kSuccess ||
        gemm.initialize(args, workspace, &q) != cutlass::Status::kSuccess ||
        gemm.run(&q) != cutlass::Status::kSuccess) {
        std::cerr << "GEMM failed\n";
        return EXIT_FAILURE;
    }
    q.wait();

    q.memcpy(h_d.data(), d_d, h_d.size() * sizeof(float)).wait();
    const float expected = alpha * 1.f * 2.f * static_cast<float>(k);
    if (std::abs(h_d[0] - expected) > 1e-3f) {
        std::cerr << "Mismatch: got " << h_d[0] << " expected " << expected << "\n";
        return EXIT_FAILURE;
    }

    std::cout << "OK: device-agnostic fp32 GEMM completed\n";
    sycl::free(d_a, q);
    sycl::free(d_b, q);
    sycl::free(d_c, q);
    sycl::free(d_d, q);
    if (workspace) sycl::free(workspace, q);
    return EXIT_SUCCESS;
}
```

</details>

---

## Performance

| Metric | Before | After |
|--------|--------|-------|
| Compile (device-agnostic fp32 GEMM) | Fails | OK |
| Runtime | — | No intended change |

---

## References

Fixes #

Related: [#803](https://github.com/intel/sycl-tla/pull/803)

---

## Checklist

- [x] Copyright
- [ ] Co-pilot Review
- [x] Deprecated APIs not used
