### PR TITLE
examples: add configurable MoE expert count and rows-per-expert to example 12

### DIFF
--- a/examples/12_xe20_moe_gemm_cute_interface/12_xe20_moe_gemm_cute_interface.cpp
+++ b/examples/12_xe20_moe_gemm_cute_interface/12_xe20_moe_gemm_cute_interface.cpp
@@ -42,6 +42,7 @@
 
 #include <cute/tensor.hpp>
 #include <random>
+#include <vector>
 
 #include <cute/util/compat.hpp>
 #include <sycl/ext/intel/experimental/grf_size_properties.hpp>
@@ -74,18 +75,22 @@ using ElementAccumulator = float; // <- data type of accumulator
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+// Number of experts covered by the built-in measured row-count table below.
+static constexpr int kDefaultTableExperts = 32;
+
 // Command line options parsing
 struct Options {
 
   bool help;
   bool error;
 
-  int n, k, num_layers, verify;
+  int n, k, num_layers, verify, experts, rows_per_expert;
 
   Options():
     help(false),
     error(false),
-    n(2880), k(2880), num_layers(24), verify(1)
+    n(2880), k(2880), num_layers(24), verify(1),
+    experts(kDefaultTableExperts), rows_per_expert(0)
   { }
 
   // Parses the command line
@@ -101,6 +106,34 @@ struct Options {
     cmd.get_cmd_line_argument("k", k, 2880);
     cmd.get_cmd_line_argument("num_layers", num_layers, 24);
     cmd.get_cmd_line_argument("verify", verify, 1);
+    cmd.get_cmd_line_argument("experts", experts, kDefaultTableExperts);
+    cmd.get_cmd_line_argument("rows_per_expert", rows_per_expert, 0);
+
+    if (experts <= 0) {
+      std::cerr << "ERROR: --experts=" << experts
+                << " is invalid. The expert count must be positive." << std::endl;
+      error = true;
+      return;
+    }
+
+    if (rows_per_expert < 0) {
+      std::cerr << "ERROR: --rows_per_expert=" << rows_per_expert
+                << " is invalid. Pass a positive value for a uniform fill, or omit\n"
+                << "       the option to use the built-in measured row table."
+                << std::endl;
+      error = true;
+      return;
+    }
+
+    if (rows_per_expert == 0 && experts > kDefaultTableExperts) {
+      std::cerr << "ERROR: --experts=" << experts
+                << " exceeds the " << kDefaultTableExperts
+                << " experts covered by the built-in row table.\n"
+                << "       Pass --rows_per_expert=<int> to supply a uniform fill instead."
+                << std::endl;
+      error = true;
+      return;
+    }
   }
 
   /// Prints the usage statement.
@@ -112,7 +145,14 @@ struct Options {
       << "  --n=<int>                   Sets the N extent of the MoE GEMM (default: 2880)\n"
       << "  --k=<int>                   Sets the K extent of the MoE GEMM (default: 2880)\n"
       << "  --num_layers=<int>          Number of layers to test (default: 24)\n"
-      << "  --verify=<int>              Specify whether to verify (0=no, 1=yes, default: 1)\n\n";
+      << "  --verify=<int>              Specify whether to verify (0=no, 1=yes, default: 1)\n"
+      << "  --experts=<int>             Number of experts per layer. Values above " << kDefaultTableExperts << " require\n"
+      << "                              --rows_per_expert, since the built-in table only covers " << kDefaultTableExperts << ".\n"
+      << "                              (default: " << kDefaultTableExperts << ")\n"
+      << "  --rows_per_expert=<int>     Give every expert this many rows, replacing the built-in\n"
+      << "                              measured table. Use it to sweep throughput against MoE\n"
+      << "                              fill; routing at top_k over many experts lands far below\n"
+      << "                              the table mean. (default: 0 = use the built-in table)\n\n";
 
     return out;
   }
@@ -419,7 +459,12 @@ int main(int argc, const char **argv) {
     return 0;
   }
 
-  constexpr int num_experts = 32;
+  if (options.error) {
+    std::cerr << "Aborting execution." << std::endl;
+    return -1;
+  }
+
+  const int num_experts = options.experts;
   constexpr int max_layers = 24;
 
   if (options.num_layers > max_layers) {
@@ -430,7 +475,7 @@ int main(int argc, const char **argv) {
     return -1;
   }
 
-  int total_rows_for_each_expert[max_layers][num_experts] = {
+  static const int default_rows_for_each_expert[max_layers][kDefaultTableExperts] = {
       {148, 231, 404, 180, 127, 244, 224, 244, 110, 617, 289,
        845, 191, 424, 30,  97,  57,  324, 62,  77,  75,  144,
        250, 287, 629, 370, 161, 101, 215, 113, 224, 35},
@@ -496,10 +541,47 @@ int main(int argc, const char **argv) {
        33, 77, 6,    22, 73, 9, 8, 587, 1486, 32,  10, 244,  37,  0,   100, 9}};
 
   int num_layers = std::min(options.num_layers, max_layers);
-  
+
+  // Effective per-expert row counts. With --rows_per_expert unset the built-in
+  // measured table is used verbatim, so existing invocations are unchanged.
+  // With --rows_per_expert=<int> every expert is given the same row count,
+  // which makes throughput-versus-fill directly sweepable.
+  std::vector<int> rows_for_each_expert(static_cast<size_t>(max_layers) *
+                                        static_cast<size_t>(num_experts));
+  for (int l = 0; l < max_layers; ++l) {
+    for (int e = 0; e < num_experts; ++e) {
+      rows_for_each_expert[static_cast<size_t>(l) * num_experts + e] =
+          options.rows_per_expert > 0 ? options.rows_per_expert
+                                      : default_rows_for_each_expert[l][e];
+    }
+  }
+
+  double total_rows = 0.0;
+  for (int l = 0; l < num_layers; ++l) {
+    for (int e = 0; e < num_experts; ++e) {
+      total_rows +=
+          rows_for_each_expert[static_cast<size_t>(l) * num_experts + e];
+    }
+  }
+
+  std::cout << "MoE fill configuration" << std::endl;
+  std::cout << "  Experts          : " << num_experts << std::endl;
+  std::cout << "  Layers           : " << num_layers << std::endl;
+  if (options.rows_per_expert > 0) {
+    std::cout << "  Rows/expert      : uniform " << options.rows_per_expert
+              << std::endl;
+  } else {
+    std::cout << "  Rows/expert      : built-in measured table" << std::endl;
+  }
+  std::cout << "  Mean rows/expert : "
+            << (total_rows / (double(num_layers) * double(num_experts)))
+            << std::endl;
+
   for (int i = 0; i < num_layers; i++) {
-    launcher(total_rows_for_each_expert[i], 2 * options.n, options.k, num_experts, options.verify);
-    launcher(total_rows_for_each_expert[i], options.k, options.n, num_experts, options.verify);
+    int *layer_rows = rows_for_each_expert.data() +
+                      static_cast<size_t>(i) * static_cast<size_t>(num_experts);
+    launcher(layer_rows, 2 * options.n, options.k, num_experts, options.verify);
+    launcher(layer_rows, options.k, options.n, num_experts, options.verify);
   }
 
   return 0;


### PR DESCRIPTION
## Feature

`examples/12_xe20_moe_gemm_cute_interface` gains two options:

- `--experts=<int>` — number of experts per layer (default 32, unchanged)
- `--rows_per_expert=<int>` — give every expert this many rows, replacing the
  built-in measured table (default 0 = use the built-in table, unchanged)

It also prints the effective configuration, so a result is self-describing:

```
MoE fill configuration
  Experts          : 32
  Layers           : 24
  Rows/expert      : built-in measured table
  Mean rows/expert : 250.824
```

Follow-up to #855.

## Use Case

The example previously fixed `num_experts` at 32 and drew per-expert row counts
from a fixed 24x32 in-source table, so the `GFLOPS` it prints could only be
obtained at one fill unless you edited the source.

That matters because at fixed `--n`/`--k` the printed rate is dominated by fill.
On Arc Pro B70 (Battlemage G31), 32 experts, `--n=2880 --k=2880 --num_layers=24
--verify=0`, median over 24 layers of the `N=5760, K=2880` leg:

| rows/expert | TFLOP/s (median) | kernel ms (median) |
|---|---|---|
| built-in table | 82.1 | 3.2510 |
| uniform 250 | 112.7 | 2.3550 |
| uniform 120 | 59.5 | 2.1419 |
| uniform 70 | 35.7 | 2.0821 |
| uniform 30 | 14.7 | 2.1663 |

From uniform 30 to uniform 250 the FLOP count rises 8.3x and the reported rate
rises 7.7x, while kernel time rises 1.09x — the leg is bound by streaming expert
weights at these fills, so the rate largely reports `sum_e M_e`. Routed MoE
inference operates near the low end of that table (top_k over tens to hundreds
of experts), which is exactly the region that previously required a source edit
to reach.

## API

Additive only. Both options are parsed with the existing `cutlass::CommandLine`
idiom next to `--n`/`--k`/`--num_layers`/`--verify`, and validated with the same
`error = true` pattern used by `examples/10_bmg_grouped_gemm_mixed_dtype`:

- `--experts` must be positive
- `--rows_per_expert` must be non-negative
- `--experts` above 32 requires `--rows_per_expert`, since the built-in table
  only has 32 columns; the diagnostic says so explicitly

`main()` gained the standard `if (options.error) { ... return -1; }` block that
sibling examples already use.

The per-layer row array became a `std::vector<int>` because the expert count is
now a runtime value; the literal table is untouched and is now a
`static const int [max_layers][kDefaultTableExperts]` that seeds the vector when
`--rows_per_expert` is not supplied.

## Example

```
# built-in table (current default, byte-for-byte the previous behaviour)
./12_xe20_moe_gemm_cute_interface --n=2880 --k=2880 --num_layers=24 --verify=0

# sweep fill at fixed shape and expert count
for r in 30 70 120 250; do
  ./12_xe20_moe_gemm_cute_interface --n=2880 --k=2880 --num_layers=24 \
      --verify=0 --rows_per_expert=$r
done

# a wider expert count, which requires an explicit uniform fill
./12_xe20_moe_gemm_cute_interface --n=2048 --k=3072 --experts=85 --rows_per_expert=30
```

## Testing

Built and run on Arc Pro B70 (Battlemage G31), driver `1.15.39122+12`, NEO
`26.27.39122.12`, oneAPI 2026.1, JIT `spir64`, `SYCL_UR_USE_LEVEL_ZERO_V2=0`.

- Builds clean via `cmake --build build-sycl --target 12_xe20_moe_gemm_cute_interface`.
- **Default behaviour preserved.** With no new flags the example reports
  `Mean rows/expert : 250.824`. I independently brace-parsed the 24x32 table
  literal out of the source (768 entries, every inner group verified length 32)
  and its mean is 250.8 — so the vector path reproduces the table exactly. The
  CMake test arguments `--n=2880 --k=2880 --num_layers=24` are unaffected and
  need no change.
- **Validation exercised.** `--experts=85` without `--rows_per_expert` prints the
  diagnostic and aborts with `-1`:
  ```
  ERROR: --experts=85 exceeds the 32 experts covered by the built-in row table.
         Pass --rows_per_expert=<int> to supply a uniform fill instead.
  Aborting execution.
  ```
- **Sweep exercised.** The five-fill table above, plus `--experts=85
  --rows_per_expert={30,120,230}` at `--n=2048 --k=3072`, all run to completion.

Not tested: PVC, and `verify=1` at `--experts` > 32 (the correctness reference
path was not touched, but I only exercised it at the default expert count).

## ToDo

None that I'm aware of. If you'd rather have the flag spelled `--fill`, or want
the CMake test arguments extended to cover a second fill point in CI, say so and
I'll adjust.
